### PR TITLE
feat: add execution id to redmesh attestations

### DIFF
--- a/.openzeppelin/base-sepolia.json
+++ b/.openzeppelin/base-sepolia.json
@@ -137,12 +137,10 @@
     },
     {
       "address": "0x428ca2fb6e543B5c159d1e6a124B615AeA15f497",
-      "txHash": "0x2aed4817d168694e253b03c9b95dddfd649bba642bb50a4f8b1e132705ead292",
       "kind": "transparent"
     },
     {
       "address": "0x6AEE4B13904B4cbeaCc8e9bBE8e25ed399C3ba69",
-      "txHash": "0x6d4e0adadd8fa07a2b6f9cb6a9ec1e92c91f66f2279718347417b2ca78874403",
       "kind": "transparent"
     }
   ],
@@ -37366,9 +37364,8 @@
         }
       }
     },
-    "661b4468d487a5cb729002fb6e91898ab369f8490b663671ffa68cc0082f39c4": {
+    "72abb8d0f724337383325d81d7a102e823139175f60a7615f19e8344241484eb": {
       "address": "0x6Be44b6939008D8652A1b0d9686eAfB5B028d5df",
-      "txHash": "0x10857f739888b0d43c56174f65204f3cea141c7245a0c1af0bc01c8dd2a1d2c2",
       "layout": {
         "solcVersion": "0.8.22",
         "storage": [
@@ -37378,23 +37375,39 @@
             "slot": "0",
             "type": "t_address",
             "contract": "AttestationRegistry",
-            "src": "contracts/AttestationRegistry.sol:46"
+            "src": "contracts/AttestationRegistry.sol:68"
           },
           {
-            "label": "redmeshAttestations",
+            "label": "redmeshTestAttestations",
             "offset": 0,
             "slot": "1",
-            "type": "t_array(t_struct(RedmeshAttestation)19928_storage)dyn_storage",
+            "type": "t_array(t_struct(RedmeshTestAttestation)5964_storage)dyn_storage",
             "contract": "AttestationRegistry",
-            "src": "contracts/AttestationRegistry.sol:47"
+            "src": "contracts/AttestationRegistry.sol:69"
           },
           {
-            "label": "tenantToRedmeshAttestationIndexes",
+            "label": "tenantToRedmeshTestAttestationIndexes",
             "offset": 0,
             "slot": "2",
             "type": "t_mapping(t_address,t_array(t_uint32)dyn_storage)",
             "contract": "AttestationRegistry",
-            "src": "contracts/AttestationRegistry.sol:48"
+            "src": "contracts/AttestationRegistry.sol:70"
+          },
+          {
+            "label": "redmeshJobStartAttestations",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_array(t_struct(RedmeshJobStartAttestation)5979_storage)dyn_storage",
+            "contract": "AttestationRegistry",
+            "src": "contracts/AttestationRegistry.sol:71"
+          },
+          {
+            "label": "tenantToRedmeshJobStartAttestationIndexes",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_mapping(t_address,t_array(t_uint32)dyn_storage)",
+            "contract": "AttestationRegistry",
+            "src": "contracts/AttestationRegistry.sol:72"
           }
         ],
         "types": {
@@ -37440,8 +37453,12 @@
             "label": "uint64",
             "numberOfBytes": "8"
           },
-          "t_array(t_struct(RedmeshAttestation)19928_storage)dyn_storage": {
-            "label": "struct AttestationRegistry.RedmeshAttestation[]",
+          "t_array(t_struct(RedmeshJobStartAttestation)5979_storage)dyn_storage": {
+            "label": "struct AttestationRegistry.RedmeshJobStartAttestation[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_struct(RedmeshTestAttestation)5964_storage)dyn_storage": {
+            "label": "struct AttestationRegistry.RedmeshTestAttestation[]",
             "numberOfBytes": "32"
           },
           "t_array(t_uint32)dyn_storage": {
@@ -37456,12 +37473,20 @@
             "label": "bytes2",
             "numberOfBytes": "2"
           },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_bytes8": {
+            "label": "bytes8",
+            "numberOfBytes": "8"
+          },
           "t_mapping(t_address,t_array(t_uint32)dyn_storage)": {
             "label": "mapping(address => uint32[])",
             "numberOfBytes": "32"
           },
-          "t_struct(RedmeshAttestation)19928_storage": {
-            "label": "struct AttestationRegistry.RedmeshAttestation",
+          "t_struct(RedmeshJobStartAttestation)5979_storage": {
+            "label": "struct AttestationRegistry.RedmeshJobStartAttestation",
             "members": [
               {
                 "label": "node",
@@ -37470,39 +37495,93 @@
                 "slot": "0"
               },
               {
-                "label": "nodeCount",
-                "type": "t_uint16",
+                "label": "ipObfuscated",
+                "type": "t_bytes2",
                 "offset": 20,
                 "slot": "0"
               },
               {
-                "label": "vulnerabilityScore",
-                "type": "t_uint8",
+                "label": "executionId",
+                "type": "t_bytes8",
                 "offset": 22,
+                "slot": "0"
+              },
+              {
+                "label": "nodeCount",
+                "type": "t_uint16",
+                "offset": 30,
                 "slot": "0"
               },
               {
                 "label": "testMode",
                 "type": "t_uint8",
-                "offset": 23,
-                "slot": "0"
-              },
-              {
-                "label": "ipObfuscated",
-                "type": "t_bytes2",
-                "offset": 24,
-                "slot": "0"
-              },
-              {
-                "label": "cidObfuscated",
-                "type": "t_bytes10",
                 "offset": 0,
                 "slot": "1"
               },
               {
                 "label": "tenant",
                 "type": "t_address",
-                "offset": 10,
+                "offset": 1,
+                "slot": "1"
+              },
+              {
+                "label": "nodeHashes",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_struct(RedmeshTestAttestation)5964_storage": {
+            "label": "struct AttestationRegistry.RedmeshTestAttestation",
+            "members": [
+              {
+                "label": "node",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "cidObfuscated",
+                "type": "t_bytes10",
+                "offset": 20,
+                "slot": "0"
+              },
+              {
+                "label": "ipObfuscated",
+                "type": "t_bytes2",
+                "offset": 30,
+                "slot": "0"
+              },
+              {
+                "label": "executionId",
+                "type": "t_bytes8",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "tenant",
+                "type": "t_address",
+                "offset": 8,
+                "slot": "1"
+              },
+              {
+                "label": "nodeCount",
+                "type": "t_uint16",
+                "offset": 28,
+                "slot": "1"
+              },
+              {
+                "label": "testMode",
+                "type": "t_uint8",
+                "offset": 30,
+                "slot": "1"
+              },
+              {
+                "label": "vulnerabilityScore",
+                "type": "t_uint8",
+                "offset": 31,
                 "slot": "1"
               }
             ],
@@ -37551,7 +37630,10 @@
             }
           ]
         }
-      }
+      },
+      "allAddresses": [
+        "0x6Be44b6939008D8652A1b0d9686eAfB5B028d5df"
+      ]
     }
   }
 }

--- a/.openzeppelin/base-sepolia.json
+++ b/.openzeppelin/base-sepolia.json
@@ -37400,6 +37400,270 @@
             "type": "t_array(t_struct(RedmeshJobStartAttestation)5979_storage)dyn_storage",
             "contract": "AttestationRegistry",
             "src": "contracts/AttestationRegistry.sol:71"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)73_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)13_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_struct(RedmeshJobStartAttestation)5979_storage)dyn_storage": {
+            "label": "struct AttestationRegistry.RedmeshJobStartAttestation[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_struct(RedmeshTestAttestation)5964_storage)dyn_storage": {
+            "label": "struct AttestationRegistry.RedmeshTestAttestation[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint32)dyn_storage": {
+            "label": "uint32[]",
+            "numberOfBytes": "32"
+          },
+          "t_bytes10": {
+            "label": "bytes10",
+            "numberOfBytes": "10"
+          },
+          "t_bytes2": {
+            "label": "bytes2",
+            "numberOfBytes": "2"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_bytes8": {
+            "label": "bytes8",
+            "numberOfBytes": "8"
+          },
+          "t_mapping(t_address,t_array(t_uint32)dyn_storage)": {
+            "label": "mapping(address => uint32[])",
+            "numberOfBytes": "32"
+          },
+          "t_struct(RedmeshJobStartAttestation)5979_storage": {
+            "label": "struct AttestationRegistry.RedmeshJobStartAttestation",
+            "members": [
+              {
+                "label": "node",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "ipObfuscated",
+                "type": "t_bytes2",
+                "offset": 20,
+                "slot": "0"
+              },
+              {
+                "label": "executionId",
+                "type": "t_bytes8",
+                "offset": 22,
+                "slot": "0"
+              },
+              {
+                "label": "nodeCount",
+                "type": "t_uint16",
+                "offset": 30,
+                "slot": "0"
+              },
+              {
+                "label": "testMode",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "tenant",
+                "type": "t_address",
+                "offset": 1,
+                "slot": "1"
+              },
+              {
+                "label": "nodeHashes",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_struct(RedmeshTestAttestation)5964_storage": {
+            "label": "struct AttestationRegistry.RedmeshTestAttestation",
+            "members": [
+              {
+                "label": "node",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "cidObfuscated",
+                "type": "t_bytes10",
+                "offset": 20,
+                "slot": "0"
+              },
+              {
+                "label": "ipObfuscated",
+                "type": "t_bytes2",
+                "offset": 30,
+                "slot": "0"
+              },
+              {
+                "label": "executionId",
+                "type": "t_bytes8",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "tenant",
+                "type": "t_address",
+                "offset": 8,
+                "slot": "1"
+              },
+              {
+                "label": "nodeCount",
+                "type": "t_uint16",
+                "offset": 28,
+                "slot": "1"
+              },
+              {
+                "label": "testMode",
+                "type": "t_uint8",
+                "offset": 30,
+                "slot": "1"
+              },
+              {
+                "label": "vulnerabilityScore",
+                "type": "t_uint8",
+                "offset": 31,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      },
+      "allAddresses": [
+        "0x6Be44b6939008D8652A1b0d9686eAfB5B028d5df"
+      ]
+    },
+    "9ab35a70b201b123153885da502f43c8db6ece18a0129df6d9667771811be0e7": {
+      "address": "0x3dB37Ab513793DdCC52FaBD1d3a7b54Ba557B2d3",
+      "txHash": "0x764a6796494242301aef83de3eaea077a42811361fd546f1e005f9066473228c",
+      "layout": {
+        "solcVersion": "0.8.22",
+        "storage": [
+          {
+            "label": "poaiManager",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_address",
+            "contract": "AttestationRegistry",
+            "src": "contracts/AttestationRegistry.sol:68"
+          },
+          {
+            "label": "redmeshTestAttestations",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_struct(RedmeshTestAttestation)5964_storage)dyn_storage",
+            "contract": "AttestationRegistry",
+            "src": "contracts/AttestationRegistry.sol:69"
+          },
+          {
+            "label": "tenantToRedmeshTestAttestationIndexes",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_mapping(t_address,t_array(t_uint32)dyn_storage)",
+            "contract": "AttestationRegistry",
+            "src": "contracts/AttestationRegistry.sol:70"
+          },
+          {
+            "label": "redmeshJobStartAttestations",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_array(t_struct(RedmeshJobStartAttestation)5979_storage)dyn_storage",
+            "contract": "AttestationRegistry",
+            "src": "contracts/AttestationRegistry.sol:71"
           },
           {
             "label": "tenantToRedmeshJobStartAttestationIndexes",
@@ -37630,10 +37894,7 @@
             }
           ]
         }
-      },
-      "allAddresses": [
-        "0x6Be44b6939008D8652A1b0d9686eAfB5B028d5df"
-      ]
+      }
     }
   }
 }

--- a/.openzeppelin/base.json
+++ b/.openzeppelin/base.json
@@ -52,7 +52,6 @@
     },
     {
       "address": "0x0602d03E7d4646E9b22F633D8751F03502b17861",
-      "txHash": "0x4a73e269873f4eefa85d57833a9369343ab525a91b40ac56058266c4e25bbd10",
       "kind": "transparent"
     }
   ],
@@ -15780,9 +15779,8 @@
         }
       }
     },
-    "661b4468d487a5cb729002fb6e91898ab369f8490b663671ffa68cc0082f39c4": {
+    "72abb8d0f724337383325d81d7a102e823139175f60a7615f19e8344241484eb": {
       "address": "0x556034b22767161C1F9CE5990EC50F47d2705eb3",
-      "txHash": "0x7aa540563851b843ef2508fc58a1640fc3198026754e0e3147a6e353b5ccca96",
       "layout": {
         "solcVersion": "0.8.22",
         "storage": [
@@ -15792,23 +15790,39 @@
             "slot": "0",
             "type": "t_address",
             "contract": "AttestationRegistry",
-            "src": "contracts/AttestationRegistry.sol:46"
+            "src": "contracts/AttestationRegistry.sol:68"
           },
           {
-            "label": "redmeshAttestations",
+            "label": "redmeshTestAttestations",
             "offset": 0,
             "slot": "1",
-            "type": "t_array(t_struct(RedmeshAttestation)6995_storage)dyn_storage",
+            "type": "t_array(t_struct(RedmeshTestAttestation)5964_storage)dyn_storage",
             "contract": "AttestationRegistry",
-            "src": "contracts/AttestationRegistry.sol:47"
+            "src": "contracts/AttestationRegistry.sol:69"
           },
           {
-            "label": "tenantToRedmeshAttestationIndexes",
+            "label": "tenantToRedmeshTestAttestationIndexes",
             "offset": 0,
             "slot": "2",
             "type": "t_mapping(t_address,t_array(t_uint32)dyn_storage)",
             "contract": "AttestationRegistry",
-            "src": "contracts/AttestationRegistry.sol:48"
+            "src": "contracts/AttestationRegistry.sol:70"
+          },
+          {
+            "label": "redmeshJobStartAttestations",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_array(t_struct(RedmeshJobStartAttestation)5979_storage)dyn_storage",
+            "contract": "AttestationRegistry",
+            "src": "contracts/AttestationRegistry.sol:71"
+          },
+          {
+            "label": "tenantToRedmeshJobStartAttestationIndexes",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_mapping(t_address,t_array(t_uint32)dyn_storage)",
+            "contract": "AttestationRegistry",
+            "src": "contracts/AttestationRegistry.sol:72"
           }
         ],
         "types": {
@@ -15854,8 +15868,12 @@
             "label": "uint64",
             "numberOfBytes": "8"
           },
-          "t_array(t_struct(RedmeshAttestation)6995_storage)dyn_storage": {
-            "label": "struct AttestationRegistry.RedmeshAttestation[]",
+          "t_array(t_struct(RedmeshJobStartAttestation)5979_storage)dyn_storage": {
+            "label": "struct AttestationRegistry.RedmeshJobStartAttestation[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_struct(RedmeshTestAttestation)5964_storage)dyn_storage": {
+            "label": "struct AttestationRegistry.RedmeshTestAttestation[]",
             "numberOfBytes": "32"
           },
           "t_array(t_uint32)dyn_storage": {
@@ -15870,12 +15888,20 @@
             "label": "bytes2",
             "numberOfBytes": "2"
           },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_bytes8": {
+            "label": "bytes8",
+            "numberOfBytes": "8"
+          },
           "t_mapping(t_address,t_array(t_uint32)dyn_storage)": {
             "label": "mapping(address => uint32[])",
             "numberOfBytes": "32"
           },
-          "t_struct(RedmeshAttestation)6995_storage": {
-            "label": "struct AttestationRegistry.RedmeshAttestation",
+          "t_struct(RedmeshJobStartAttestation)5979_storage": {
+            "label": "struct AttestationRegistry.RedmeshJobStartAttestation",
             "members": [
               {
                 "label": "node",
@@ -15884,39 +15910,93 @@
                 "slot": "0"
               },
               {
-                "label": "nodeCount",
-                "type": "t_uint16",
+                "label": "ipObfuscated",
+                "type": "t_bytes2",
                 "offset": 20,
                 "slot": "0"
               },
               {
-                "label": "vulnerabilityScore",
-                "type": "t_uint8",
+                "label": "executionId",
+                "type": "t_bytes8",
                 "offset": 22,
+                "slot": "0"
+              },
+              {
+                "label": "nodeCount",
+                "type": "t_uint16",
+                "offset": 30,
                 "slot": "0"
               },
               {
                 "label": "testMode",
                 "type": "t_uint8",
-                "offset": 23,
-                "slot": "0"
-              },
-              {
-                "label": "ipObfuscated",
-                "type": "t_bytes2",
-                "offset": 24,
-                "slot": "0"
-              },
-              {
-                "label": "cidObfuscated",
-                "type": "t_bytes10",
                 "offset": 0,
                 "slot": "1"
               },
               {
                 "label": "tenant",
                 "type": "t_address",
-                "offset": 10,
+                "offset": 1,
+                "slot": "1"
+              },
+              {
+                "label": "nodeHashes",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_struct(RedmeshTestAttestation)5964_storage": {
+            "label": "struct AttestationRegistry.RedmeshTestAttestation",
+            "members": [
+              {
+                "label": "node",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "cidObfuscated",
+                "type": "t_bytes10",
+                "offset": 20,
+                "slot": "0"
+              },
+              {
+                "label": "ipObfuscated",
+                "type": "t_bytes2",
+                "offset": 30,
+                "slot": "0"
+              },
+              {
+                "label": "executionId",
+                "type": "t_bytes8",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "tenant",
+                "type": "t_address",
+                "offset": 8,
+                "slot": "1"
+              },
+              {
+                "label": "nodeCount",
+                "type": "t_uint16",
+                "offset": 28,
+                "slot": "1"
+              },
+              {
+                "label": "testMode",
+                "type": "t_uint8",
+                "offset": 30,
+                "slot": "1"
+              },
+              {
+                "label": "vulnerabilityScore",
+                "type": "t_uint8",
+                "offset": 31,
                 "slot": "1"
               }
             ],

--- a/.openzeppelin/base.json
+++ b/.openzeppelin/base.json
@@ -15815,14 +15815,6 @@
             "type": "t_array(t_struct(RedmeshJobStartAttestation)5979_storage)dyn_storage",
             "contract": "AttestationRegistry",
             "src": "contracts/AttestationRegistry.sol:71"
-          },
-          {
-            "label": "tenantToRedmeshJobStartAttestationIndexes",
-            "offset": 0,
-            "slot": "4",
-            "type": "t_mapping(t_address,t_array(t_uint32)dyn_storage)",
-            "contract": "AttestationRegistry",
-            "src": "contracts/AttestationRegistry.sol:72"
           }
         ],
         "types": {

--- a/contracts/AttestationRegistry.sol
+++ b/contracts/AttestationRegistry.sol
@@ -17,7 +17,7 @@ contract AttestationRegistry is Initializable, OwnableUpgradeable {
         CONTINUOUS
     }
 
-    struct RedmeshAttestation {
+    struct RedmeshTestAttestation {
         address node;
         bytes10 cidObfuscated;
         bytes2 ipObfuscated;
@@ -28,12 +28,22 @@ contract AttestationRegistry is Initializable, OwnableUpgradeable {
         uint8 vulnerabilityScore;
     }
 
+    struct RedmeshJobStartAttestation {
+        address node;
+        bytes2 ipObfuscated;
+        bytes8 executionId;
+        uint16 nodeCount;
+        uint8 testMode;
+        address tenant;
+        bytes32 nodeHashes;
+    }
+
     error InvalidAddress();
     error InvalidTestMode();
     error InvalidVulnerabilityScore();
     error AttestationIndexOverflow();
 
-    event RedmeshAttestationStored(
+    event RedmeshTestAttestationStored(
         uint256 index,
         address indexed node,
         uint8 testMode,
@@ -44,10 +54,22 @@ contract AttestationRegistry is Initializable, OwnableUpgradeable {
         bytes10 cidObfuscated,
         address indexed submitter
     );
+    event RedmeshJobStartAttestationStored(
+        uint256 index,
+        address indexed node,
+        uint8 testMode,
+        uint16 nodeCount,
+        bytes8 executionId,
+        bytes32 nodeHashes,
+        bytes2 ipObfuscated,
+        address indexed submitter
+    );
 
     address public poaiManager;
-    RedmeshAttestation[] private redmeshAttestations;
-    mapping(address => uint32[]) private tenantToRedmeshAttestationIndexes;
+    RedmeshTestAttestation[] private redmeshTestAttestations;
+    mapping(address => uint32[]) private tenantToRedmeshTestAttestationIndexes;
+    RedmeshJobStartAttestation[] private redmeshJobStartAttestations;
+    mapping(address => uint32[]) private tenantToRedmeshJobStartAttestationIndexes;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -68,30 +90,30 @@ contract AttestationRegistry is Initializable, OwnableUpgradeable {
         poaiManager = poaiManager_;
     }
 
-    function getRedmeshAttestationCount() external view returns (uint256) {
-        return redmeshAttestations.length;
+    function getRedmeshTestAttestationCount() external view returns (uint256) {
+        return redmeshTestAttestations.length;
     }
 
-    function getTenantRedmeshAttestationIndexCount(
+    function getTenantRedmeshTestAttestationIndexCount(
         address tenant
     ) external view returns (uint256) {
-        return tenantToRedmeshAttestationIndexes[tenant].length;
+        return tenantToRedmeshTestAttestationIndexes[tenant].length;
     }
 
-    function getRedmeshAttestation(
+    function getRedmeshTestAttestation(
         uint256 index
-    ) external view returns (RedmeshAttestation memory) {
-        return redmeshAttestations[index];
+    ) external view returns (RedmeshTestAttestation memory) {
+        return redmeshTestAttestations[index];
     }
 
-    function getRedmeshAttestations(
+    function getRedmeshTestAttestations(
         uint256 offset,
         uint256 limit,
         bool latestFirst
-    ) external view returns (RedmeshAttestation[] memory) {
-        uint256 total = redmeshAttestations.length;
+    ) external view returns (RedmeshTestAttestation[] memory) {
+        uint256 total = redmeshTestAttestations.length;
         if (offset >= total || limit == 0) {
-            return new RedmeshAttestation[](0);
+            return new RedmeshTestAttestation[](0);
         }
 
         uint256 count = total - offset;
@@ -99,27 +121,29 @@ contract AttestationRegistry is Initializable, OwnableUpgradeable {
             count = limit;
         }
 
-        RedmeshAttestation[] memory page = new RedmeshAttestation[](count);
+        RedmeshTestAttestation[] memory page = new RedmeshTestAttestation[](
+            count
+        );
         if (latestFirst) {
             uint256 start = total - 1 - offset;
             for (uint256 i = 0; i < count; i++) {
-                page[i] = redmeshAttestations[start - i];
+                page[i] = redmeshTestAttestations[start - i];
             }
         } else {
             for (uint256 i = 0; i < count; i++) {
-                page[i] = redmeshAttestations[offset + i];
+                page[i] = redmeshTestAttestations[offset + i];
             }
         }
         return page;
     }
 
-    function getTenantRedmeshAttestationIndexes(
+    function getTenantRedmeshTestAttestationIndexes(
         address tenant,
         uint256 offset,
         uint256 limit,
         bool latestFirst
     ) external view returns (uint256[] memory) {
-        uint32[] storage tenantIndexes = tenantToRedmeshAttestationIndexes[
+        uint32[] storage tenantIndexes = tenantToRedmeshTestAttestationIndexes[
             tenant
         ];
         uint256 total = tenantIndexes.length;
@@ -146,7 +170,87 @@ contract AttestationRegistry is Initializable, OwnableUpgradeable {
         return page;
     }
 
-    function getRedmeshAttestationDigest(
+    function getRedmeshJobStartAttestationCount() external view returns (uint256) {
+        return redmeshJobStartAttestations.length;
+    }
+
+    function getTenantRedmeshJobStartAttestationIndexCount(
+        address tenant
+    ) external view returns (uint256) {
+        return tenantToRedmeshJobStartAttestationIndexes[tenant].length;
+    }
+
+    function getRedmeshJobStartAttestation(
+        uint256 index
+    ) external view returns (RedmeshJobStartAttestation memory) {
+        return redmeshJobStartAttestations[index];
+    }
+
+    function getRedmeshJobStartAttestations(
+        uint256 offset,
+        uint256 limit,
+        bool latestFirst
+    ) external view returns (RedmeshJobStartAttestation[] memory) {
+        uint256 total = redmeshJobStartAttestations.length;
+        if (offset >= total || limit == 0) {
+            return new RedmeshJobStartAttestation[](0);
+        }
+
+        uint256 count = total - offset;
+        if (limit < count) {
+            count = limit;
+        }
+
+        RedmeshJobStartAttestation[] memory page = new RedmeshJobStartAttestation[](
+                count
+            );
+        if (latestFirst) {
+            uint256 start = total - 1 - offset;
+            for (uint256 i = 0; i < count; i++) {
+                page[i] = redmeshJobStartAttestations[start - i];
+            }
+        } else {
+            for (uint256 i = 0; i < count; i++) {
+                page[i] = redmeshJobStartAttestations[offset + i];
+            }
+        }
+        return page;
+    }
+
+    function getTenantRedmeshJobStartAttestationIndexes(
+        address tenant,
+        uint256 offset,
+        uint256 limit,
+        bool latestFirst
+    ) external view returns (uint256[] memory) {
+        uint32[] storage tenantIndexes = tenantToRedmeshJobStartAttestationIndexes[
+                tenant
+            ];
+        uint256 total = tenantIndexes.length;
+        if (offset >= total || limit == 0) {
+            return new uint256[](0);
+        }
+
+        uint256 count = total - offset;
+        if (limit < count) {
+            count = limit;
+        }
+
+        uint256[] memory page = new uint256[](count);
+        if (latestFirst) {
+            uint256 start = total - 1 - offset;
+            for (uint256 i = 0; i < count; i++) {
+                page[i] = uint256(tenantIndexes[start - i]);
+            }
+        } else {
+            for (uint256 i = 0; i < count; i++) {
+                page[i] = uint256(tenantIndexes[offset + i]);
+            }
+        }
+        return page;
+    }
+
+    function getRedmeshTestAttestationDigest(
         uint8 testMode,
         uint16 nodeCount,
         uint8 vulnerabilityScore,
@@ -168,7 +272,27 @@ contract AttestationRegistry is Initializable, OwnableUpgradeable {
             );
     }
 
-    function submitRedmeshAttestation(
+    function getRedmeshJobStartAttestationDigest(
+        uint8 testMode,
+        uint16 nodeCount,
+        bytes8 executionId,
+        bytes32 nodeHashes,
+        bytes2 ipObfuscated
+    ) public pure returns (bytes32) {
+        return
+            keccak256(
+                abi.encodePacked(
+                    REDMESH_ATTESTATION_DOMAIN,
+                    testMode,
+                    nodeCount,
+                    executionId,
+                    nodeHashes,
+                    ipObfuscated
+                )
+            );
+    }
+
+    function submitRedmeshTestAttestation(
         uint8 testMode,
         uint16 nodeCount,
         uint8 vulnerabilityScore,
@@ -186,7 +310,7 @@ contract AttestationRegistry is Initializable, OwnableUpgradeable {
         address submitter = msg.sender;
 
         {
-            bytes32 digest = getRedmeshAttestationDigest(
+            bytes32 digest = getRedmeshTestAttestationDigest(
                 testMode,
                 nodeCount,
                 vulnerabilityScore,
@@ -201,8 +325,8 @@ contract AttestationRegistry is Initializable, OwnableUpgradeable {
         // attestations, verify `node` is active for that job in PoAIManager
         // before storing.
 
-        redmeshAttestations.push(
-            RedmeshAttestation({
+        redmeshTestAttestations.push(
+            RedmeshTestAttestation({
                 node: node,
                 cidObfuscated: cidObfuscated,
                 ipObfuscated: ipObfuscated,
@@ -213,14 +337,14 @@ contract AttestationRegistry is Initializable, OwnableUpgradeable {
                 vulnerabilityScore: vulnerabilityScore
             })
         );
-        index = redmeshAttestations.length - 1;
+        index = redmeshTestAttestations.length - 1;
         if (index > type(uint32).max) {
             revert AttestationIndexOverflow();
         }
-        tenantToRedmeshAttestationIndexes[submitter].push(uint32(index));
-        RedmeshAttestation storage stored = redmeshAttestations[index];
+        tenantToRedmeshTestAttestationIndexes[submitter].push(uint32(index));
+        RedmeshTestAttestation storage stored = redmeshTestAttestations[index];
 
-        emit RedmeshAttestationStored(
+        emit RedmeshTestAttestationStored(
             index,
             node,
             stored.testMode,
@@ -229,6 +353,66 @@ contract AttestationRegistry is Initializable, OwnableUpgradeable {
             stored.executionId,
             stored.ipObfuscated,
             stored.cidObfuscated,
+            submitter
+        );
+    }
+
+    function submitRedmeshJobStartAttestation(
+        uint8 testMode,
+        uint16 nodeCount,
+        bytes8 executionId,
+        bytes32 nodeHashes,
+        bytes2 ipObfuscated,
+        bytes calldata nodeSignature
+    ) external returns (uint256 index, address node) {
+        if (testMode > uint8(RedmeshTestMode.CONTINUOUS)) {
+            revert InvalidTestMode();
+        }
+        address submitter = msg.sender;
+
+        {
+            bytes32 digest = getRedmeshJobStartAttestationDigest(
+                testMode,
+                nodeCount,
+                executionId,
+                nodeHashes,
+                ipObfuscated
+            );
+            node = ECDSA.recover(digest.toEthSignedMessageHash(), nodeSignature);
+        }
+
+        // TODO: when external job references are added back to RedMesh
+        // attestations, verify `node` is active for that job in PoAIManager
+        // before storing.
+
+        redmeshJobStartAttestations.push(
+            RedmeshJobStartAttestation({
+                node: node,
+                ipObfuscated: ipObfuscated,
+                executionId: executionId,
+                nodeCount: nodeCount,
+                testMode: testMode,
+                tenant: submitter,
+                nodeHashes: nodeHashes
+            })
+        );
+        index = redmeshJobStartAttestations.length - 1;
+        if (index > type(uint32).max) {
+            revert AttestationIndexOverflow();
+        }
+        tenantToRedmeshJobStartAttestationIndexes[submitter].push(uint32(index));
+        RedmeshJobStartAttestation storage stored = redmeshJobStartAttestations[
+            index
+        ];
+
+        emit RedmeshJobStartAttestationStored(
+            index,
+            node,
+            stored.testMode,
+            stored.nodeCount,
+            stored.executionId,
+            stored.nodeHashes,
+            stored.ipObfuscated,
             submitter
         );
     }

--- a/contracts/AttestationRegistry.sol
+++ b/contracts/AttestationRegistry.sol
@@ -59,7 +59,7 @@ contract AttestationRegistry is Initializable, OwnableUpgradeable {
         address indexed node,
         uint8 testMode,
         uint16 nodeCount,
-        bytes8 executionId,
+        bytes8 indexed executionId,
         bytes32 nodeHashes,
         bytes2 ipObfuscated,
         address indexed submitter
@@ -69,7 +69,8 @@ contract AttestationRegistry is Initializable, OwnableUpgradeable {
     RedmeshTestAttestation[] private redmeshTestAttestations;
     mapping(address => uint32[]) private tenantToRedmeshTestAttestationIndexes;
     RedmeshJobStartAttestation[] private redmeshJobStartAttestations;
-    mapping(address => uint32[]) private tenantToRedmeshJobStartAttestationIndexes;
+    mapping(address => uint32[])
+        private tenantToRedmeshJobStartAttestationIndexes;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -170,7 +171,11 @@ contract AttestationRegistry is Initializable, OwnableUpgradeable {
         return page;
     }
 
-    function getRedmeshJobStartAttestationCount() external view returns (uint256) {
+    function getRedmeshJobStartAttestationCount()
+        external
+        view
+        returns (uint256)
+    {
         return redmeshJobStartAttestations.length;
     }
 
@@ -201,9 +206,8 @@ contract AttestationRegistry is Initializable, OwnableUpgradeable {
             count = limit;
         }
 
-        RedmeshJobStartAttestation[] memory page = new RedmeshJobStartAttestation[](
-                count
-            );
+        RedmeshJobStartAttestation[]
+            memory page = new RedmeshJobStartAttestation[](count);
         if (latestFirst) {
             uint256 start = total - 1 - offset;
             for (uint256 i = 0; i < count; i++) {
@@ -223,7 +227,8 @@ contract AttestationRegistry is Initializable, OwnableUpgradeable {
         uint256 limit,
         bool latestFirst
     ) external view returns (uint256[] memory) {
-        uint32[] storage tenantIndexes = tenantToRedmeshJobStartAttestationIndexes[
+        uint32[]
+            storage tenantIndexes = tenantToRedmeshJobStartAttestationIndexes[
                 tenant
             ];
         uint256 total = tenantIndexes.length;
@@ -318,7 +323,10 @@ contract AttestationRegistry is Initializable, OwnableUpgradeable {
                 ipObfuscated,
                 cidObfuscated
             );
-            node = ECDSA.recover(digest.toEthSignedMessageHash(), nodeSignature);
+            node = ECDSA.recover(
+                digest.toEthSignedMessageHash(),
+                nodeSignature
+            );
         }
 
         // TODO: when external job references are added back to RedMesh
@@ -378,7 +386,10 @@ contract AttestationRegistry is Initializable, OwnableUpgradeable {
                 nodeHashes,
                 ipObfuscated
             );
-            node = ECDSA.recover(digest.toEthSignedMessageHash(), nodeSignature);
+            node = ECDSA.recover(
+                digest.toEthSignedMessageHash(),
+                nodeSignature
+            );
         }
 
         // TODO: when external job references are added back to RedMesh
@@ -400,7 +411,9 @@ contract AttestationRegistry is Initializable, OwnableUpgradeable {
         if (index > type(uint32).max) {
             revert AttestationIndexOverflow();
         }
-        tenantToRedmeshJobStartAttestationIndexes[submitter].push(uint32(index));
+        tenantToRedmeshJobStartAttestationIndexes[submitter].push(
+            uint32(index)
+        );
         RedmeshJobStartAttestation storage stored = redmeshJobStartAttestations[
             index
         ];

--- a/contracts/AttestationRegistry.sol
+++ b/contracts/AttestationRegistry.sol
@@ -19,12 +19,13 @@ contract AttestationRegistry is Initializable, OwnableUpgradeable {
 
     struct RedmeshAttestation {
         address node;
-        uint16 nodeCount;
-        uint8 vulnerabilityScore;
-        uint8 testMode;
-        bytes2 ipObfuscated;
         bytes10 cidObfuscated;
+        bytes2 ipObfuscated;
+        bytes8 executionId;
         address tenant;
+        uint16 nodeCount;
+        uint8 testMode;
+        uint8 vulnerabilityScore;
     }
 
     error InvalidAddress();
@@ -33,11 +34,12 @@ contract AttestationRegistry is Initializable, OwnableUpgradeable {
     error AttestationIndexOverflow();
 
     event RedmeshAttestationStored(
-        uint256 indexed index,
+        uint256 index,
         address indexed node,
         uint8 testMode,
         uint16 nodeCount,
         uint8 vulnerabilityScore,
+        bytes8 indexed executionId,
         bytes2 ipObfuscated,
         bytes10 cidObfuscated,
         address indexed submitter
@@ -148,6 +150,7 @@ contract AttestationRegistry is Initializable, OwnableUpgradeable {
         uint8 testMode,
         uint16 nodeCount,
         uint8 vulnerabilityScore,
+        bytes8 executionId,
         bytes2 ipObfuscated,
         bytes10 cidObfuscated
     ) public pure returns (bytes32) {
@@ -158,6 +161,7 @@ contract AttestationRegistry is Initializable, OwnableUpgradeable {
                     testMode,
                     nodeCount,
                     vulnerabilityScore,
+                    executionId,
                     ipObfuscated,
                     cidObfuscated
                 )
@@ -168,6 +172,7 @@ contract AttestationRegistry is Initializable, OwnableUpgradeable {
         uint8 testMode,
         uint16 nodeCount,
         uint8 vulnerabilityScore,
+        bytes8 executionId,
         bytes2 ipObfuscated,
         bytes10 cidObfuscated,
         bytes calldata nodeSignature
@@ -178,47 +183,53 @@ contract AttestationRegistry is Initializable, OwnableUpgradeable {
         if (vulnerabilityScore > 100) {
             revert InvalidVulnerabilityScore();
         }
+        address submitter = msg.sender;
 
-        bytes32 digest = getRedmeshAttestationDigest(
-            testMode,
-            nodeCount,
-            vulnerabilityScore,
-            ipObfuscated,
-            cidObfuscated
-        );
-
-        node = ECDSA.recover(digest.toEthSignedMessageHash(), nodeSignature);
+        {
+            bytes32 digest = getRedmeshAttestationDigest(
+                testMode,
+                nodeCount,
+                vulnerabilityScore,
+                executionId,
+                ipObfuscated,
+                cidObfuscated
+            );
+            node = ECDSA.recover(digest.toEthSignedMessageHash(), nodeSignature);
+        }
 
         // TODO: when external job references are added back to RedMesh
         // attestations, verify `node` is active for that job in PoAIManager
         // before storing.
 
-        RedmeshAttestation memory attestation = RedmeshAttestation({
-            node: node,
-            nodeCount: nodeCount,
-            vulnerabilityScore: vulnerabilityScore,
-            testMode: testMode,
-            ipObfuscated: ipObfuscated,
-            cidObfuscated: cidObfuscated,
-            tenant: msg.sender
-        });
-
-        redmeshAttestations.push(attestation);
+        redmeshAttestations.push(
+            RedmeshAttestation({
+                node: node,
+                cidObfuscated: cidObfuscated,
+                ipObfuscated: ipObfuscated,
+                executionId: executionId,
+                tenant: submitter,
+                nodeCount: nodeCount,
+                testMode: testMode,
+                vulnerabilityScore: vulnerabilityScore
+            })
+        );
         index = redmeshAttestations.length - 1;
         if (index > type(uint32).max) {
             revert AttestationIndexOverflow();
         }
-        tenantToRedmeshAttestationIndexes[msg.sender].push(uint32(index));
+        tenantToRedmeshAttestationIndexes[submitter].push(uint32(index));
+        RedmeshAttestation storage stored = redmeshAttestations[index];
 
         emit RedmeshAttestationStored(
             index,
             node,
-            testMode,
-            nodeCount,
-            vulnerabilityScore,
-            ipObfuscated,
-            cidObfuscated,
-            msg.sender
+            stored.testMode,
+            stored.nodeCount,
+            stored.vulnerabilityScore,
+            stored.executionId,
+            stored.ipObfuscated,
+            stored.cidObfuscated,
+            submitter
         );
     }
 }

--- a/test/AttestationRegistry.test.ts
+++ b/test/AttestationRegistry.test.ts
@@ -14,6 +14,7 @@ describe("AttestationRegistry", function () {
   const TEST_MODE_SINGLE = 0;
   const NODE_COUNT = 3;
   const VULNERABILITY_SCORE = 74;
+  const EXECUTION_ID = "0x6a6f623030303031"; // job00001
   const IP_OBFUSCATED = "0x863a"; // 134..58
   const CID_OBFUSCATED = "0x61626364657576777879"; // abcdeuvwxy
 
@@ -32,16 +33,18 @@ describe("AttestationRegistry", function () {
     testMode: number,
     nodeCount: number,
     vulnerabilityScore: number,
+    executionId: string,
     ipObfuscated: string,
     cidObfuscated: string
   ): string {
     return ethers.solidityPackedKeccak256(
-      ["bytes32", "uint8", "uint16", "uint8", "bytes2", "bytes10"],
+      ["bytes32", "uint8", "uint16", "uint8", "bytes8", "bytes2", "bytes10"],
       [
         DOMAIN,
         testMode,
         nodeCount,
         vulnerabilityScore,
+        executionId,
         ipObfuscated,
         cidObfuscated,
       ]
@@ -53,6 +56,7 @@ describe("AttestationRegistry", function () {
     testMode = TEST_MODE_SINGLE,
     nodeCount = NODE_COUNT,
     vulnerabilityScore = VULNERABILITY_SCORE,
+    executionId = EXECUTION_ID,
     ipObfuscated = IP_OBFUSCATED,
     cidObfuscated = CID_OBFUSCATED
   ): Promise<string> {
@@ -60,6 +64,7 @@ describe("AttestationRegistry", function () {
       testMode,
       nodeCount,
       vulnerabilityScore,
+      executionId,
       ipObfuscated,
       cidObfuscated
     );
@@ -77,6 +82,7 @@ describe("AttestationRegistry", function () {
       TEST_MODE_SINGLE,
       NODE_COUNT,
       VULNERABILITY_SCORE,
+      EXECUTION_ID,
       IP_OBFUSCATED,
       CID_OBFUSCATED
     );
@@ -85,6 +91,7 @@ describe("AttestationRegistry", function () {
         TEST_MODE_SINGLE,
         NODE_COUNT,
         VULNERABILITY_SCORE,
+        EXECUTION_ID,
         IP_OBFUSCATED,
         CID_OBFUSCATED
       )
@@ -97,6 +104,7 @@ describe("AttestationRegistry", function () {
           TEST_MODE_SINGLE,
           NODE_COUNT,
           VULNERABILITY_SCORE,
+          EXECUTION_ID,
           IP_OBFUSCATED,
           CID_OBFUSCATED,
           signature
@@ -109,6 +117,7 @@ describe("AttestationRegistry", function () {
         TEST_MODE_SINGLE,
         NODE_COUNT,
         VULNERABILITY_SCORE,
+        EXECUTION_ID,
         IP_OBFUSCATED,
         CID_OBFUSCATED,
         relayer.address
@@ -120,6 +129,7 @@ describe("AttestationRegistry", function () {
     expect(attestation.nodeCount).to.equal(NODE_COUNT);
     expect(attestation.vulnerabilityScore).to.equal(VULNERABILITY_SCORE);
     expect(attestation.testMode).to.equal(TEST_MODE_SINGLE);
+    expect(attestation.executionId).to.equal(EXECUTION_ID);
     expect(attestation.ipObfuscated).to.equal(IP_OBFUSCATED);
     expect(attestation.cidObfuscated).to.equal(CID_OBFUSCATED);
     expect(attestation.tenant).to.equal(relayer.address);
@@ -131,6 +141,7 @@ describe("AttestationRegistry", function () {
       TEST_MODE_SINGLE,
       NODE_COUNT,
       101,
+      EXECUTION_ID,
       IP_OBFUSCATED,
       CID_OBFUSCATED
     );
@@ -140,6 +151,7 @@ describe("AttestationRegistry", function () {
         TEST_MODE_SINGLE,
         NODE_COUNT,
         101,
+        EXECUTION_ID,
         IP_OBFUSCATED,
         CID_OBFUSCATED,
         signature
@@ -154,6 +166,7 @@ describe("AttestationRegistry", function () {
       invalidTestMode,
       NODE_COUNT,
       VULNERABILITY_SCORE,
+      EXECUTION_ID,
       IP_OBFUSCATED,
       CID_OBFUSCATED
     );
@@ -163,6 +176,7 @@ describe("AttestationRegistry", function () {
         invalidTestMode,
         NODE_COUNT,
         VULNERABILITY_SCORE,
+        EXECUTION_ID,
         IP_OBFUSCATED,
         CID_OBFUSCATED,
         signature
@@ -176,6 +190,7 @@ describe("AttestationRegistry", function () {
         TEST_MODE_SINGLE,
         NODE_COUNT,
         VULNERABILITY_SCORE,
+        EXECUTION_ID,
         IP_OBFUSCATED,
         CID_OBFUSCATED,
         "0x1234"
@@ -189,6 +204,7 @@ describe("AttestationRegistry", function () {
       TEST_MODE_SINGLE,
       NODE_COUNT,
       VULNERABILITY_SCORE,
+      EXECUTION_ID,
       IP_OBFUSCATED,
       CID_OBFUSCATED,
       signature
@@ -197,6 +213,7 @@ describe("AttestationRegistry", function () {
       TEST_MODE_SINGLE,
       NODE_COUNT,
       VULNERABILITY_SCORE,
+      EXECUTION_ID,
       IP_OBFUSCATED,
       CID_OBFUSCATED,
       signature
@@ -229,6 +246,7 @@ describe("AttestationRegistry", function () {
       TEST_MODE_SINGLE,
       NODE_COUNT,
       10,
+      EXECUTION_ID,
       IP_OBFUSCATED,
       CID_OBFUSCATED,
       firstSig
@@ -237,6 +255,7 @@ describe("AttestationRegistry", function () {
       TEST_MODE_SINGLE,
       NODE_COUNT,
       20,
+      EXECUTION_ID,
       IP_OBFUSCATED,
       CID_OBFUSCATED,
       secondSig
@@ -245,6 +264,7 @@ describe("AttestationRegistry", function () {
       TEST_MODE_SINGLE,
       NODE_COUNT,
       30,
+      EXECUTION_ID,
       IP_OBFUSCATED,
       CID_OBFUSCATED,
       thirdSig
@@ -273,6 +293,7 @@ describe("AttestationRegistry", function () {
       TEST_MODE_SINGLE,
       NODE_COUNT,
       10,
+      EXECUTION_ID,
       IP_OBFUSCATED,
       CID_OBFUSCATED,
       sig10
@@ -281,6 +302,7 @@ describe("AttestationRegistry", function () {
       TEST_MODE_SINGLE,
       NODE_COUNT,
       20,
+      EXECUTION_ID,
       IP_OBFUSCATED,
       CID_OBFUSCATED,
       sig20
@@ -289,6 +311,7 @@ describe("AttestationRegistry", function () {
       TEST_MODE_SINGLE,
       NODE_COUNT,
       30,
+      EXECUTION_ID,
       IP_OBFUSCATED,
       CID_OBFUSCATED,
       sig30

--- a/test/AttestationRegistry.test.ts
+++ b/test/AttestationRegistry.test.ts
@@ -10,13 +10,19 @@ describe("AttestationRegistry", function () {
   let relayer: HardhatEthersSigner;
   let other: HardhatEthersSigner;
 
-  const DOMAIN = ethers.keccak256(ethers.toUtf8Bytes("RATIO1_REDMESH_ATTESTATION_V1"));
+  const DOMAIN = ethers.keccak256(
+    ethers.toUtf8Bytes("RATIO1_REDMESH_ATTESTATION_V1")
+  );
+
   const TEST_MODE_SINGLE = 0;
+  const TEST_MODE_CONTINUOUS = 1;
+
   const NODE_COUNT = 3;
   const VULNERABILITY_SCORE = 74;
   const EXECUTION_ID = "0x6a6f623030303031"; // job00001
   const IP_OBFUSCATED = "0x863a"; // 134..58
   const CID_OBFUSCATED = "0x61626364657576777879"; // abcdeuvwxy
+  const NODE_HASHES = ethers.keccak256(ethers.toUtf8Bytes("nodes-v1"));
 
   async function deployRegistry(): Promise<AttestationRegistry> {
     const factory = await ethers.getContractFactory("AttestationRegistry");
@@ -29,7 +35,7 @@ describe("AttestationRegistry", function () {
     return contract as unknown as AttestationRegistry;
   }
 
-  function buildDigest(
+  function buildTestDigest(
     testMode: number,
     nodeCount: number,
     vulnerabilityScore: number,
@@ -51,7 +57,20 @@ describe("AttestationRegistry", function () {
     );
   }
 
-  async function signAttestation(
+  function buildJobStartDigest(
+    testMode: number,
+    nodeCount: number,
+    executionId: string,
+    nodeHashes: string,
+    ipObfuscated: string
+  ): string {
+    return ethers.solidityPackedKeccak256(
+      ["bytes32", "uint8", "uint16", "bytes8", "bytes32", "bytes2"],
+      [DOMAIN, testMode, nodeCount, executionId, nodeHashes, ipObfuscated]
+    );
+  }
+
+  async function signTestAttestation(
     signer: HardhatEthersSigner,
     testMode = TEST_MODE_SINGLE,
     nodeCount = NODE_COUNT,
@@ -60,7 +79,7 @@ describe("AttestationRegistry", function () {
     ipObfuscated = IP_OBFUSCATED,
     cidObfuscated = CID_OBFUSCATED
   ): Promise<string> {
-    const digest = buildDigest(
+    const digest = buildTestDigest(
       testMode,
       nodeCount,
       vulnerabilityScore,
@@ -71,37 +90,128 @@ describe("AttestationRegistry", function () {
     return signer.signMessage(ethers.getBytes(digest));
   }
 
+  async function signJobStartAttestation(
+    signer: HardhatEthersSigner,
+    testMode = TEST_MODE_SINGLE,
+    nodeCount = NODE_COUNT,
+    executionId = EXECUTION_ID,
+    nodeHashes = NODE_HASHES,
+    ipObfuscated = IP_OBFUSCATED
+  ): Promise<string> {
+    const digest = buildJobStartDigest(
+      testMode,
+      nodeCount,
+      executionId,
+      nodeHashes,
+      ipObfuscated
+    );
+    return signer.signMessage(ethers.getBytes(digest));
+  }
+
   beforeEach(async function () {
     [owner, nodeSigner, relayer, other] = await ethers.getSigners();
     registry = await deployRegistry();
   });
 
-  it("stores attestation using recovered node signer even when tx sender differs", async function () {
-    const signature = await signAttestation(nodeSigner);
-    const expectedDigest = buildDigest(
-      TEST_MODE_SINGLE,
-      NODE_COUNT,
-      VULNERABILITY_SCORE,
-      EXECUTION_ID,
-      IP_OBFUSCATED,
-      CID_OBFUSCATED
-    );
-    expect(
-      await registry.getRedmeshAttestationDigest(
+  describe("RedmeshTestAttestation", function () {
+    it("stores test attestation using recovered node signer even when tx sender differs", async function () {
+      const signature = await signTestAttestation(nodeSigner);
+      const expectedDigest = buildTestDigest(
         TEST_MODE_SINGLE,
         NODE_COUNT,
         VULNERABILITY_SCORE,
         EXECUTION_ID,
         IP_OBFUSCATED,
         CID_OBFUSCATED
-      )
-    ).to.equal(expectedDigest);
-
-    await expect(
-      registry
-        .connect(relayer)
-        .submitRedmeshAttestation(
+      );
+      expect(
+        await registry.getRedmeshTestAttestationDigest(
           TEST_MODE_SINGLE,
+          NODE_COUNT,
+          VULNERABILITY_SCORE,
+          EXECUTION_ID,
+          IP_OBFUSCATED,
+          CID_OBFUSCATED
+        )
+      ).to.equal(expectedDigest);
+
+      await expect(
+        registry
+          .connect(relayer)
+          .submitRedmeshTestAttestation(
+            TEST_MODE_SINGLE,
+            NODE_COUNT,
+            VULNERABILITY_SCORE,
+            EXECUTION_ID,
+            IP_OBFUSCATED,
+            CID_OBFUSCATED,
+            signature
+          )
+      )
+        .to.emit(registry, "RedmeshTestAttestationStored")
+        .withArgs(
+          0,
+          nodeSigner.address,
+          TEST_MODE_SINGLE,
+          NODE_COUNT,
+          VULNERABILITY_SCORE,
+          EXECUTION_ID,
+          IP_OBFUSCATED,
+          CID_OBFUSCATED,
+          relayer.address
+        );
+
+      expect(await registry.getRedmeshTestAttestationCount()).to.equal(1);
+      const attestation = await registry.getRedmeshTestAttestation(0);
+      expect(attestation.node).to.equal(nodeSigner.address);
+      expect(attestation.nodeCount).to.equal(NODE_COUNT);
+      expect(attestation.vulnerabilityScore).to.equal(VULNERABILITY_SCORE);
+      expect(attestation.testMode).to.equal(TEST_MODE_SINGLE);
+      expect(attestation.executionId).to.equal(EXECUTION_ID);
+      expect(attestation.ipObfuscated).to.equal(IP_OBFUSCATED);
+      expect(attestation.cidObfuscated).to.equal(CID_OBFUSCATED);
+      expect(attestation.tenant).to.equal(relayer.address);
+    });
+
+    it("reverts when vulnerability score exceeds 100", async function () {
+      const signature = await signTestAttestation(
+        nodeSigner,
+        TEST_MODE_SINGLE,
+        NODE_COUNT,
+        101,
+        EXECUTION_ID,
+        IP_OBFUSCATED,
+        CID_OBFUSCATED
+      );
+
+      await expect(
+        registry.submitRedmeshTestAttestation(
+          TEST_MODE_SINGLE,
+          NODE_COUNT,
+          101,
+          EXECUTION_ID,
+          IP_OBFUSCATED,
+          CID_OBFUSCATED,
+          signature
+        )
+      ).to.be.revertedWithCustomError(registry, "InvalidVulnerabilityScore");
+    });
+
+    it("reverts when test mode is out of range", async function () {
+      const invalidTestMode = 2;
+      const signature = await signTestAttestation(
+        nodeSigner,
+        invalidTestMode,
+        NODE_COUNT,
+        VULNERABILITY_SCORE,
+        EXECUTION_ID,
+        IP_OBFUSCATED,
+        CID_OBFUSCATED
+      );
+
+      await expect(
+        registry.submitRedmeshTestAttestation(
+          invalidTestMode,
           NODE_COUNT,
           VULNERABILITY_SCORE,
           EXECUTION_ID,
@@ -109,264 +219,415 @@ describe("AttestationRegistry", function () {
           CID_OBFUSCATED,
           signature
         )
-    )
-      .to.emit(registry, "RedmeshAttestationStored")
-      .withArgs(
-        0,
-        nodeSigner.address,
+      ).to.be.revertedWithCustomError(registry, "InvalidTestMode");
+    });
+
+    it("reverts when node signature is malformed", async function () {
+      await expect(
+        registry.submitRedmeshTestAttestation(
+          TEST_MODE_SINGLE,
+          NODE_COUNT,
+          VULNERABILITY_SCORE,
+          EXECUTION_ID,
+          IP_OBFUSCATED,
+          CID_OBFUSCATED,
+          "0x1234"
+        )
+      ).to.be.reverted;
+    });
+
+    it("accepts duplicate test attestations", async function () {
+      const signature = await signTestAttestation(nodeSigner);
+      await registry.submitRedmeshTestAttestation(
         TEST_MODE_SINGLE,
         NODE_COUNT,
         VULNERABILITY_SCORE,
         EXECUTION_ID,
         IP_OBFUSCATED,
         CID_OBFUSCATED,
-        relayer.address
+        signature
+      );
+      await registry.submitRedmeshTestAttestation(
+        TEST_MODE_SINGLE,
+        NODE_COUNT,
+        VULNERABILITY_SCORE,
+        EXECUTION_ID,
+        IP_OBFUSCATED,
+        CID_OBFUSCATED,
+        signature
       );
 
-    expect(await registry.getRedmeshAttestationCount()).to.equal(1);
-    const attestation = await registry.getRedmeshAttestation(0);
-    expect(attestation.node).to.equal(nodeSigner.address);
-    expect(attestation.nodeCount).to.equal(NODE_COUNT);
-    expect(attestation.vulnerabilityScore).to.equal(VULNERABILITY_SCORE);
-    expect(attestation.testMode).to.equal(TEST_MODE_SINGLE);
-    expect(attestation.executionId).to.equal(EXECUTION_ID);
-    expect(attestation.ipObfuscated).to.equal(IP_OBFUSCATED);
-    expect(attestation.cidObfuscated).to.equal(CID_OBFUSCATED);
-    expect(attestation.tenant).to.equal(relayer.address);
-  });
+      expect(await registry.getRedmeshTestAttestationCount()).to.equal(2);
+    });
 
-  it("reverts when vulnerability score exceeds 100", async function () {
-    const signature = await signAttestation(
-      nodeSigner,
-      TEST_MODE_SINGLE,
-      NODE_COUNT,
-      101,
-      EXECUTION_ID,
-      IP_OBFUSCATED,
-      CID_OBFUSCATED
-    );
-
-    await expect(
-      registry.submitRedmeshAttestation(
+    it("returns paginated test attestations in both orders", async function () {
+      const firstSig = await signTestAttestation(
+        nodeSigner,
         TEST_MODE_SINGLE,
         NODE_COUNT,
-        101,
+        10
+      );
+      const secondSig = await signTestAttestation(
+        nodeSigner,
+        TEST_MODE_SINGLE,
+        NODE_COUNT,
+        20
+      );
+      const thirdSig = await signTestAttestation(
+        nodeSigner,
+        TEST_MODE_SINGLE,
+        NODE_COUNT,
+        30
+      );
+
+      await registry.submitRedmeshTestAttestation(
+        TEST_MODE_SINGLE,
+        NODE_COUNT,
+        10,
         EXECUTION_ID,
         IP_OBFUSCATED,
         CID_OBFUSCATED,
-        signature
-      )
-    ).to.be.revertedWithCustomError(registry, "InvalidVulnerabilityScore");
+        firstSig
+      );
+      await registry.submitRedmeshTestAttestation(
+        TEST_MODE_SINGLE,
+        NODE_COUNT,
+        20,
+        EXECUTION_ID,
+        IP_OBFUSCATED,
+        CID_OBFUSCATED,
+        secondSig
+      );
+      await registry.submitRedmeshTestAttestation(
+        TEST_MODE_SINGLE,
+        NODE_COUNT,
+        30,
+        EXECUTION_ID,
+        IP_OBFUSCATED,
+        CID_OBFUSCATED,
+        thirdSig
+      );
+
+      const forward = await registry.getRedmeshTestAttestations(1, 2, false);
+      expect(forward.length).to.equal(2);
+      expect(forward[0].vulnerabilityScore).to.equal(20);
+      expect(forward[1].vulnerabilityScore).to.equal(30);
+
+      const reverse = await registry.getRedmeshTestAttestations(1, 2, true);
+      expect(reverse.length).to.equal(2);
+      expect(reverse[0].vulnerabilityScore).to.equal(20);
+      expect(reverse[1].vulnerabilityScore).to.equal(10);
+
+      const empty = await registry.getRedmeshTestAttestations(10, 2, true);
+      expect(empty.length).to.equal(0);
+    });
+
+    it("tracks tenant test attestation indexes by submitter wallet", async function () {
+      const sig10 = await signTestAttestation(
+        nodeSigner,
+        TEST_MODE_SINGLE,
+        NODE_COUNT,
+        10
+      );
+      const sig20 = await signTestAttestation(
+        nodeSigner,
+        TEST_MODE_SINGLE,
+        NODE_COUNT,
+        20
+      );
+      const sig30 = await signTestAttestation(
+        nodeSigner,
+        TEST_MODE_SINGLE,
+        NODE_COUNT,
+        30
+      );
+
+      await registry
+        .connect(relayer)
+        .submitRedmeshTestAttestation(
+          TEST_MODE_SINGLE,
+          NODE_COUNT,
+          10,
+          EXECUTION_ID,
+          IP_OBFUSCATED,
+          CID_OBFUSCATED,
+          sig10
+        );
+      await registry
+        .connect(owner)
+        .submitRedmeshTestAttestation(
+          TEST_MODE_SINGLE,
+          NODE_COUNT,
+          20,
+          EXECUTION_ID,
+          IP_OBFUSCATED,
+          CID_OBFUSCATED,
+          sig20
+        );
+      await registry
+        .connect(relayer)
+        .submitRedmeshTestAttestation(
+          TEST_MODE_SINGLE,
+          NODE_COUNT,
+          30,
+          EXECUTION_ID,
+          IP_OBFUSCATED,
+          CID_OBFUSCATED,
+          sig30
+        );
+
+      expect(
+        await registry.getTenantRedmeshTestAttestationIndexCount(
+          relayer.address
+        )
+      ).to.equal(2);
+      expect(
+        await registry.getTenantRedmeshTestAttestationIndexCount(owner.address)
+      ).to.equal(1);
+      expect(
+        await registry.getTenantRedmeshTestAttestationIndexCount(other.address)
+      ).to.equal(0);
+
+      const relayerForward =
+        await registry.getTenantRedmeshTestAttestationIndexes(
+          relayer.address,
+          0,
+          10,
+          false
+        );
+      expect(relayerForward.length).to.equal(2);
+      expect(relayerForward[0]).to.equal(0);
+      expect(relayerForward[1]).to.equal(2);
+
+      const relayerReverse =
+        await registry.getTenantRedmeshTestAttestationIndexes(
+          relayer.address,
+          0,
+          10,
+          true
+        );
+      expect(relayerReverse.length).to.equal(2);
+      expect(relayerReverse[0]).to.equal(2);
+      expect(relayerReverse[1]).to.equal(0);
+
+      const ownerAttestation = await registry.getRedmeshTestAttestation(1);
+      expect(ownerAttestation.tenant).to.equal(owner.address);
+    });
   });
 
-  it("reverts when test mode is out of range", async function () {
-    const invalidTestMode = 2;
-    const signature = await signAttestation(
-      nodeSigner,
-      invalidTestMode,
-      NODE_COUNT,
-      VULNERABILITY_SCORE,
-      EXECUTION_ID,
-      IP_OBFUSCATED,
-      CID_OBFUSCATED
-    );
+  describe("RedmeshJobStartAttestation", function () {
+    it("stores job-start attestation using recovered node signer even when tx sender differs", async function () {
+      const signature = await signJobStartAttestation(
+        nodeSigner,
+        TEST_MODE_CONTINUOUS,
+        NODE_COUNT,
+        EXECUTION_ID,
+        NODE_HASHES,
+        IP_OBFUSCATED
+      );
+      const expectedDigest = buildJobStartDigest(
+        TEST_MODE_CONTINUOUS,
+        NODE_COUNT,
+        EXECUTION_ID,
+        NODE_HASHES,
+        IP_OBFUSCATED
+      );
+      expect(
+        await registry.getRedmeshJobStartAttestationDigest(
+          TEST_MODE_CONTINUOUS,
+          NODE_COUNT,
+          EXECUTION_ID,
+          NODE_HASHES,
+          IP_OBFUSCATED
+        )
+      ).to.equal(expectedDigest);
 
-    await expect(
-      registry.submitRedmeshAttestation(
+      await expect(
+        registry
+          .connect(relayer)
+          .submitRedmeshJobStartAttestation(
+            TEST_MODE_CONTINUOUS,
+            NODE_COUNT,
+            EXECUTION_ID,
+            NODE_HASHES,
+            IP_OBFUSCATED,
+            signature
+          )
+      )
+        .to.emit(registry, "RedmeshJobStartAttestationStored")
+        .withArgs(
+          0,
+          nodeSigner.address,
+          TEST_MODE_CONTINUOUS,
+          NODE_COUNT,
+          EXECUTION_ID,
+          NODE_HASHES,
+          IP_OBFUSCATED,
+          relayer.address
+        );
+
+      expect(await registry.getRedmeshJobStartAttestationCount()).to.equal(1);
+      const attestation = await registry.getRedmeshJobStartAttestation(0);
+      expect(attestation.node).to.equal(nodeSigner.address);
+      expect(attestation.testMode).to.equal(TEST_MODE_CONTINUOUS);
+      expect(attestation.nodeCount).to.equal(NODE_COUNT);
+      expect(attestation.executionId).to.equal(EXECUTION_ID);
+      expect(attestation.nodeHashes).to.equal(NODE_HASHES);
+      expect(attestation.ipObfuscated).to.equal(IP_OBFUSCATED);
+      expect(attestation.tenant).to.equal(relayer.address);
+    });
+
+    it("reverts when job-start test mode is out of range", async function () {
+      const invalidTestMode = 2;
+      const signature = await signJobStartAttestation(
+        nodeSigner,
         invalidTestMode,
         NODE_COUNT,
-        VULNERABILITY_SCORE,
         EXECUTION_ID,
-        IP_OBFUSCATED,
-        CID_OBFUSCATED,
-        signature
-      )
-    ).to.be.revertedWithCustomError(registry, "InvalidTestMode");
-  });
+        NODE_HASHES,
+        IP_OBFUSCATED
+      );
 
-  it("reverts when node signature is malformed", async function () {
-    await expect(
-      registry.submitRedmeshAttestation(
+      await expect(
+        registry.submitRedmeshJobStartAttestation(
+          invalidTestMode,
+          NODE_COUNT,
+          EXECUTION_ID,
+          NODE_HASHES,
+          IP_OBFUSCATED,
+          signature
+        )
+      ).to.be.revertedWithCustomError(registry, "InvalidTestMode");
+    });
+
+    it("reverts when job-start signature is malformed", async function () {
+      await expect(
+        registry.submitRedmeshJobStartAttestation(
+          TEST_MODE_SINGLE,
+          NODE_COUNT,
+          EXECUTION_ID,
+          NODE_HASHES,
+          IP_OBFUSCATED,
+          "0x1234"
+        )
+      ).to.be.reverted;
+    });
+
+    it("tracks tenant job-start attestation indexes by submitter wallet", async function () {
+      const h1 = ethers.keccak256(ethers.toUtf8Bytes("nodes1"));
+      const h2 = ethers.keccak256(ethers.toUtf8Bytes("nodes2"));
+      const h3 = ethers.keccak256(ethers.toUtf8Bytes("nodes3"));
+      const s1 = await signJobStartAttestation(
+        nodeSigner,
         TEST_MODE_SINGLE,
         NODE_COUNT,
-        VULNERABILITY_SCORE,
         EXECUTION_ID,
-        IP_OBFUSCATED,
-        CID_OBFUSCATED,
-        "0x1234"
-      )
-    ).to.be.reverted;
-  });
+        h1,
+        IP_OBFUSCATED
+      );
+      const s2 = await signJobStartAttestation(
+        nodeSigner,
+        TEST_MODE_SINGLE,
+        NODE_COUNT,
+        EXECUTION_ID,
+        h2,
+        IP_OBFUSCATED
+      );
+      const s3 = await signJobStartAttestation(
+        nodeSigner,
+        TEST_MODE_SINGLE,
+        NODE_COUNT,
+        EXECUTION_ID,
+        h3,
+        IP_OBFUSCATED
+      );
 
-  it("accepts duplicate attestations (no uniqueness enforcement)", async function () {
-    const signature = await signAttestation(nodeSigner);
-    await registry.submitRedmeshAttestation(
-      TEST_MODE_SINGLE,
-      NODE_COUNT,
-      VULNERABILITY_SCORE,
-      EXECUTION_ID,
-      IP_OBFUSCATED,
-      CID_OBFUSCATED,
-      signature
-    );
-    await registry.submitRedmeshAttestation(
-      TEST_MODE_SINGLE,
-      NODE_COUNT,
-      VULNERABILITY_SCORE,
-      EXECUTION_ID,
-      IP_OBFUSCATED,
-      CID_OBFUSCATED,
-      signature
-    );
+      await registry
+        .connect(relayer)
+        .submitRedmeshJobStartAttestation(
+          TEST_MODE_SINGLE,
+          NODE_COUNT,
+          EXECUTION_ID,
+          h1,
+          IP_OBFUSCATED,
+          s1
+        );
+      await registry
+        .connect(owner)
+        .submitRedmeshJobStartAttestation(
+          TEST_MODE_SINGLE,
+          NODE_COUNT,
+          EXECUTION_ID,
+          h2,
+          IP_OBFUSCATED,
+          s2
+        );
+      await registry
+        .connect(relayer)
+        .submitRedmeshJobStartAttestation(
+          TEST_MODE_SINGLE,
+          NODE_COUNT,
+          EXECUTION_ID,
+          h3,
+          IP_OBFUSCATED,
+          s3
+        );
 
-    expect(await registry.getRedmeshAttestationCount()).to.equal(2);
-  });
+      expect(
+        await registry.getTenantRedmeshJobStartAttestationIndexCount(
+          relayer.address
+        )
+      ).to.equal(2);
+      expect(
+        await registry.getTenantRedmeshJobStartAttestationIndexCount(
+          owner.address
+        )
+      ).to.equal(1);
+      expect(
+        await registry.getTenantRedmeshJobStartAttestationIndexCount(
+          other.address
+        )
+      ).to.equal(0);
 
-  it("returns paginated attestations in both orders", async function () {
-    const firstSig = await signAttestation(
-      nodeSigner,
-      TEST_MODE_SINGLE,
-      NODE_COUNT,
-      10
-    );
-    const secondSig = await signAttestation(
-      nodeSigner,
-      TEST_MODE_SINGLE,
-      NODE_COUNT,
-      20
-    );
-    const thirdSig = await signAttestation(
-      nodeSigner,
-      TEST_MODE_SINGLE,
-      NODE_COUNT,
-      30
-    );
+      const relayerForward =
+        await registry.getTenantRedmeshJobStartAttestationIndexes(
+          relayer.address,
+          0,
+          10,
+          false
+        );
+      expect(relayerForward.length).to.equal(2);
+      expect(relayerForward[0]).to.equal(0);
+      expect(relayerForward[1]).to.equal(2);
 
-    await registry.submitRedmeshAttestation(
-      TEST_MODE_SINGLE,
-      NODE_COUNT,
-      10,
-      EXECUTION_ID,
-      IP_OBFUSCATED,
-      CID_OBFUSCATED,
-      firstSig
-    );
-    await registry.submitRedmeshAttestation(
-      TEST_MODE_SINGLE,
-      NODE_COUNT,
-      20,
-      EXECUTION_ID,
-      IP_OBFUSCATED,
-      CID_OBFUSCATED,
-      secondSig
-    );
-    await registry.submitRedmeshAttestation(
-      TEST_MODE_SINGLE,
-      NODE_COUNT,
-      30,
-      EXECUTION_ID,
-      IP_OBFUSCATED,
-      CID_OBFUSCATED,
-      thirdSig
-    );
+      const relayerReverse =
+        await registry.getTenantRedmeshJobStartAttestationIndexes(
+          relayer.address,
+          0,
+          10,
+          true
+        );
+      expect(relayerReverse.length).to.equal(2);
+      expect(relayerReverse[0]).to.equal(2);
+      expect(relayerReverse[1]).to.equal(0);
 
-    const forward = await registry.getRedmeshAttestations(1, 2, false);
-    expect(forward.length).to.equal(2);
-    expect(forward[0].vulnerabilityScore).to.equal(20);
-    expect(forward[1].vulnerabilityScore).to.equal(30);
-
-    const reverse = await registry.getRedmeshAttestations(1, 2, true);
-    expect(reverse.length).to.equal(2);
-    expect(reverse[0].vulnerabilityScore).to.equal(20);
-    expect(reverse[1].vulnerabilityScore).to.equal(10);
-
-    const empty = await registry.getRedmeshAttestations(10, 2, true);
-    expect(empty.length).to.equal(0);
-  });
-
-  it("tracks tenant attestation indexes by submitter wallet", async function () {
-    const sig10 = await signAttestation(nodeSigner, TEST_MODE_SINGLE, NODE_COUNT, 10);
-    const sig20 = await signAttestation(nodeSigner, TEST_MODE_SINGLE, NODE_COUNT, 20);
-    const sig30 = await signAttestation(nodeSigner, TEST_MODE_SINGLE, NODE_COUNT, 30);
-
-    await registry.connect(relayer).submitRedmeshAttestation(
-      TEST_MODE_SINGLE,
-      NODE_COUNT,
-      10,
-      EXECUTION_ID,
-      IP_OBFUSCATED,
-      CID_OBFUSCATED,
-      sig10
-    );
-    await registry.connect(owner).submitRedmeshAttestation(
-      TEST_MODE_SINGLE,
-      NODE_COUNT,
-      20,
-      EXECUTION_ID,
-      IP_OBFUSCATED,
-      CID_OBFUSCATED,
-      sig20
-    );
-    await registry.connect(relayer).submitRedmeshAttestation(
-      TEST_MODE_SINGLE,
-      NODE_COUNT,
-      30,
-      EXECUTION_ID,
-      IP_OBFUSCATED,
-      CID_OBFUSCATED,
-      sig30
-    );
-
-    expect(await registry.getTenantRedmeshAttestationIndexCount(relayer.address)).to.equal(2);
-    expect(await registry.getTenantRedmeshAttestationIndexCount(owner.address)).to.equal(1);
-    expect(await registry.getTenantRedmeshAttestationIndexCount(other.address)).to.equal(0);
-
-    const relayerForward = await registry.getTenantRedmeshAttestationIndexes(
-      relayer.address,
-      0,
-      10,
-      false
-    );
-    expect(relayerForward.length).to.equal(2);
-    expect(relayerForward[0]).to.equal(0);
-    expect(relayerForward[1]).to.equal(2);
-
-    const relayerReverse = await registry.getTenantRedmeshAttestationIndexes(
-      relayer.address,
-      0,
-      10,
-      true
-    );
-    expect(relayerReverse.length).to.equal(2);
-    expect(relayerReverse[0]).to.equal(2);
-    expect(relayerReverse[1]).to.equal(0);
-
-    const ownerAttestation = await registry.getRedmeshAttestation(1);
-    expect(ownerAttestation.tenant).to.equal(owner.address);
+      const ownerAttestation = await registry.getRedmeshJobStartAttestation(1);
+      expect(ownerAttestation.tenant).to.equal(owner.address);
+    });
   });
 
   it("reverts initialize for zero addresses", async function () {
     const factory = await ethers.getContractFactory("AttestationRegistry");
     await expect(
-      upgrades.deployProxy(
-        factory,
-        [ethers.ZeroAddress, owner.address],
-        { initializer: "initialize" }
-      )
-    ).to.be.revertedWithCustomError(
-      factory,
-      "InvalidAddress"
-    );
+      upgrades.deployProxy(factory, [ethers.ZeroAddress, owner.address], {
+        initializer: "initialize",
+      })
+    ).to.be.revertedWithCustomError(factory, "InvalidAddress");
 
     await expect(
-      upgrades.deployProxy(
-        factory,
-        [owner.address, ethers.ZeroAddress],
-        { initializer: "initialize" }
-      )
-    ).to.be.revertedWithCustomError(
-      factory,
-      "InvalidAddress"
-    );
+      upgrades.deployProxy(factory, [owner.address, ethers.ZeroAddress], {
+        initializer: "initialize",
+      })
+    ).to.be.revertedWithCustomError(factory, "InvalidAddress");
   });
 });


### PR DESCRIPTION
## Summary
- add `executionId` (`bytes8`) to `RedmeshAttestation`
- include `executionId` in attestation digest and `submitRedmeshAttestation` inputs
- make `executionId` indexed in `RedmeshAttestationStored` (and make `index` non-indexed to keep the 3-indexed-field limit)
- keep tenant indexing and storage behavior unchanged
- update AttestationRegistry tests for the new `executionId` field

## Validation
- `npm test --silent -- test/AttestationRegistry.test.ts`
- `npm run build --silent`
