### PR TITLE
feat: add batch job duration extension

### DIFF
--- a/contracts/CspEscrow.sol
+++ b/contracts/CspEscrow.sol
@@ -353,6 +353,74 @@ contract CspEscrow is Initializable {
         );
     }
 
+    function extendJobsDurationBatch(
+        uint256[] calldata jobIds,
+        uint256[] calldata newLastExecutionEpochs
+    ) external onlyAllowed(PERMISSION_EXTEND_DURATION) {
+        require(jobIds.length > 0, "No jobs provided");
+        require(
+            jobIds.length == newLastExecutionEpochs.length,
+            "Array length mismatch"
+        );
+
+        uint256 currentEpoch = getCurrentEpoch();
+        uint256[] memory additionalAmounts = new uint256[](jobIds.length);
+        uint256 totalAdditionalAmount = 0;
+
+        for (uint256 i = 0; i < jobIds.length; i++) {
+            JobDetails storage job = jobDetails[jobIds[i]];
+            require(job.id != 0, "Job does not exist");
+
+            uint256 newLastExecutionEpoch = newLastExecutionEpochs[i];
+            require(
+                newLastExecutionEpoch > job.lastExecutionEpoch,
+                "New epoch must be greater"
+            );
+            require(
+                newLastExecutionEpoch > currentEpoch,
+                "New epoch must be in future"
+            );
+
+            uint256 additionalEpochs = newLastExecutionEpoch -
+                job.lastExecutionEpoch;
+            require(additionalEpochs > 0, "No additional epochs");
+
+            uint256 additionalAmount = job.pricePerEpoch *
+                job.numberOfNodesRequested *
+                additionalEpochs;
+            require(additionalAmount > 0, "No additional amount");
+
+            additionalAmounts[i] = additionalAmount;
+            totalAdditionalAmount += additionalAmount;
+        }
+
+        require(totalAdditionalAmount > 0, "No additional amount");
+        require(
+            IERC20(usdcToken).transferFrom(
+                msg.sender,
+                address(this),
+                totalAdditionalAmount
+            ),
+            "USDC transfer failed"
+        );
+
+        for (uint256 i = 0; i < jobIds.length; i++) {
+            uint256 jobId = jobIds[i];
+            uint256 newLastExecutionEpoch = newLastExecutionEpochs[i];
+            uint256 additionalAmount = additionalAmounts[i];
+            JobDetails storage job = jobDetails[jobId];
+
+            job.balance += int256(additionalAmount);
+            job.lastExecutionEpoch = newLastExecutionEpoch;
+
+            emit JobDurationExtended(
+                jobId,
+                newLastExecutionEpoch,
+                additionalAmount
+            );
+        }
+    }
+
     function extendJobNodes(
         uint256 jobId,
         uint256 newNumberOfNodesRequested

--- a/contracts/CspEscrow.sol
+++ b/contracts/CspEscrow.sol
@@ -461,6 +461,67 @@ contract CspEscrow is Initializable {
         );
     }
 
+    function extendJobsNodesBatch(
+        uint256[] calldata jobIds,
+        uint256[] calldata newNumberOfNodesRequested
+    ) external onlyAllowed(PERMISSION_EXTEND_NODES) {
+        require(jobIds.length > 0, "No jobs provided");
+        require(
+            jobIds.length == newNumberOfNodesRequested.length,
+            "Array length mismatch"
+        );
+
+        uint256 currentEpoch = getCurrentEpoch();
+        uint256[] memory additionalAmounts = new uint256[](jobIds.length);
+        uint256 totalAdditionalAmount = 0;
+
+        for (uint256 i = 0; i < jobIds.length; i++) {
+            JobDetails storage job = jobDetails[jobIds[i]];
+            require(job.id != 0, "Job does not exist");
+
+            uint256 newNodesCount = newNumberOfNodesRequested[i];
+            require(
+                newNodesCount > job.numberOfNodesRequested,
+                "New number of nodes must be greater"
+            );
+            require(
+                job.lastExecutionEpoch > currentEpoch,
+                "Job has already ended"
+            );
+
+            uint256 additionalNodes = newNodesCount -
+                job.numberOfNodesRequested;
+            uint256 remainingEpochs = job.lastExecutionEpoch - currentEpoch;
+            uint256 additionalAmount = job.pricePerEpoch *
+                additionalNodes *
+                remainingEpochs;
+
+            additionalAmounts[i] = additionalAmount;
+            totalAdditionalAmount += additionalAmount;
+        }
+
+        require(
+            IERC20(usdcToken).transferFrom(
+                msg.sender,
+                address(this),
+                totalAdditionalAmount
+            ),
+            "USDC transfer failed"
+        );
+
+        for (uint256 i = 0; i < jobIds.length; i++) {
+            uint256 jobId = jobIds[i];
+            uint256 newNodesCount = newNumberOfNodesRequested[i];
+            uint256 additionalAmount = additionalAmounts[i];
+            JobDetails storage job = jobDetails[jobId];
+
+            job.balance += int256(additionalAmount);
+            job.numberOfNodesRequested = newNodesCount;
+
+            emit JobNodesExtended(jobId, newNodesCount, additionalAmount);
+        }
+    }
+
     // Receive consensus-based updates from PoAI Manager
     function updateActiveNodes(
         uint256 jobId,

--- a/test/PoAI.test.ts
+++ b/test/PoAI.test.ts
@@ -1305,6 +1305,88 @@ describe("PoAIManager", function () {
     );
   });
 
+  it("should extend multiple jobs duration in a single transaction", async function () {
+    const escrowAddress = await setupUserWithEscrow(user, oracle);
+    const CspEscrow = await ethers.getContractFactory("CspEscrow");
+    const cspEscrow: CspEscrow = CspEscrow.attach(escrowAddress) as CspEscrow;
+
+    const currentEpoch = await poaiManager.getCurrentEpoch();
+    const jobType = 1;
+    const pricePerEpoch = await cspEscrow.getPriceForJobType(jobType);
+
+    const initialEpochs = 35n;
+    const nodesJob1 = 1n;
+    const nodesJob2 = 2n;
+    const lastExecutionEpoch = currentEpoch + initialEpochs;
+
+    const initialCostJob1 = pricePerEpoch * nodesJob1 * initialEpochs;
+    const initialCostJob2 = pricePerEpoch * nodesJob2 * initialEpochs;
+    const initialTotalCost = initialCostJob1 + initialCostJob2;
+
+    await mockUsdc.mint(await user.getAddress(), initialTotalCost);
+    await mockUsdc.connect(user).approve(escrowAddress, initialTotalCost);
+
+    await cspEscrow.connect(user).createJobs([
+      {
+        jobType,
+        projectHash: ethers.keccak256(ethers.toUtf8Bytes("batch-extend-1")),
+        lastExecutionEpoch,
+        numberOfNodesRequested: nodesJob1,
+      },
+      {
+        jobType,
+        projectHash: ethers.keccak256(ethers.toUtf8Bytes("batch-extend-2")),
+        lastExecutionEpoch,
+        numberOfNodesRequested: nodesJob2,
+      },
+    ]);
+
+    const job1Before = await cspEscrow.getJobDetails(1);
+    const job2Before = await cspEscrow.getJobDetails(2);
+
+    const additionalEpochsJob1 = 10n;
+    const additionalEpochsJob2 = 15n;
+    const newLastExecutionEpochJob1 =
+      job1Before.lastExecutionEpoch + additionalEpochsJob1;
+    const newLastExecutionEpochJob2 =
+      job2Before.lastExecutionEpoch + additionalEpochsJob2;
+
+    const additionalAmountJob1 =
+      job1Before.pricePerEpoch *
+      job1Before.numberOfNodesRequested *
+      additionalEpochsJob1;
+    const additionalAmountJob2 =
+      job2Before.pricePerEpoch *
+      job2Before.numberOfNodesRequested *
+      additionalEpochsJob2;
+    const additionalTotalAmount = additionalAmountJob1 + additionalAmountJob2;
+
+    await mockUsdc.mint(await user.getAddress(), additionalTotalAmount);
+    await mockUsdc.connect(user).approve(escrowAddress, additionalTotalAmount);
+
+    await expect(
+      cspEscrow.connect(user).extendJobsDurationBatch(
+        [1n, 2n],
+        [newLastExecutionEpochJob1, newLastExecutionEpochJob2]
+      )
+    )
+      .to.emit(cspEscrow, "JobDurationExtended")
+      .withArgs(1n, newLastExecutionEpochJob1, additionalAmountJob1)
+      .and.to.emit(cspEscrow, "JobDurationExtended")
+      .withArgs(2n, newLastExecutionEpochJob2, additionalAmountJob2);
+
+    const job1After = await cspEscrow.getJobDetails(1);
+    const job2After = await cspEscrow.getJobDetails(2);
+
+    expect(job1After.lastExecutionEpoch).to.equal(newLastExecutionEpochJob1);
+    expect(job1After.balance).to.equal(job1Before.balance + additionalAmountJob1);
+    expect(job2After.lastExecutionEpoch).to.equal(newLastExecutionEpochJob2);
+    expect(job2After.balance).to.equal(job2Before.balance + additionalAmountJob2);
+    expect(await mockUsdc.balanceOf(escrowAddress)).to.equal(
+      initialTotalCost + additionalTotalAmount
+    );
+  });
+
   it("should allow CSP owner to extend job nodes with remaining epoch pricing", async function () {
     const escrowAddress = await setupUserWithEscrow(user, oracle);
     const CspEscrow = await ethers.getContractFactory("CspEscrow");

--- a/test/PoAI.test.ts
+++ b/test/PoAI.test.ts
@@ -1437,6 +1437,104 @@ describe("PoAIManager", function () {
     );
   });
 
+  it("should allow CSP owner to batch-extend job nodes", async function () {
+    const escrowAddress = await setupUserWithEscrow(user, oracle);
+    const CspEscrow = await ethers.getContractFactory("CspEscrow");
+    const cspEscrow: CspEscrow = CspEscrow.attach(escrowAddress) as CspEscrow;
+
+    const jobType = 1;
+    const currentEpoch = await poaiManager.getCurrentEpoch();
+    const initialEpochs = 45n;
+    const lastExecutionEpoch = currentEpoch + initialEpochs;
+    const nodesJob1 = 2n;
+    const nodesJob2 = 3n;
+    const pricePerEpoch = await cspEscrow.getPriceForJobType(jobType);
+
+    const initialCostJob1 = pricePerEpoch * nodesJob1 * initialEpochs;
+    const initialCostJob2 = pricePerEpoch * nodesJob2 * initialEpochs;
+    const initialTotalCost = initialCostJob1 + initialCostJob2;
+
+    await mockUsdc.mint(await user.getAddress(), initialTotalCost);
+    await mockUsdc.connect(user).approve(escrowAddress, initialTotalCost);
+
+    await cspEscrow.connect(user).createJobs([
+      {
+        jobType,
+        projectHash: ethers.keccak256(ethers.toUtf8Bytes("batch-extend-nodes-1")),
+        lastExecutionEpoch,
+        numberOfNodesRequested: nodesJob1,
+      },
+      {
+        jobType,
+        projectHash: ethers.keccak256(ethers.toUtf8Bytes("batch-extend-nodes-2")),
+        lastExecutionEpoch,
+        numberOfNodesRequested: nodesJob2,
+      },
+    ]);
+
+    const job1Before = await cspEscrow.getJobDetails(1);
+    const job2Before = await cspEscrow.getJobDetails(2);
+
+    const newNodesJob1 = nodesJob1 + 2n;
+    const newNodesJob2 = nodesJob2 + 1n;
+
+    const remainingEpochs = lastExecutionEpoch - currentEpoch;
+    const additionalAmountJob1 =
+      job1Before.pricePerEpoch * (newNodesJob1 - nodesJob1) * remainingEpochs;
+    const additionalAmountJob2 =
+      job2Before.pricePerEpoch * (newNodesJob2 - nodesJob2) * remainingEpochs;
+    const additionalTotalAmount = additionalAmountJob1 + additionalAmountJob2;
+
+    await mockUsdc.mint(await user.getAddress(), additionalTotalAmount);
+    await mockUsdc.connect(user).approve(escrowAddress, additionalTotalAmount);
+
+    await expect(
+      cspEscrow.connect(user).extendJobsNodesBatch(
+        [1n, 2n],
+        [newNodesJob1, newNodesJob2]
+      )
+    )
+      .to.emit(cspEscrow, "JobNodesExtended")
+      .withArgs(1n, newNodesJob1, additionalAmountJob1)
+      .and.to.emit(cspEscrow, "JobNodesExtended")
+      .withArgs(2n, newNodesJob2, additionalAmountJob2);
+
+    const job1After = await cspEscrow.getJobDetails(1);
+    const job2After = await cspEscrow.getJobDetails(2);
+
+    expect(job1After.numberOfNodesRequested).to.equal(newNodesJob1);
+    expect(job2After.numberOfNodesRequested).to.equal(newNodesJob2);
+    expect(job1After.balance).to.equal(job1Before.balance + additionalAmountJob1);
+    expect(job2After.balance).to.equal(job2Before.balance + additionalAmountJob2);
+    expect(await mockUsdc.balanceOf(escrowAddress)).to.equal(
+      initialTotalCost + additionalTotalAmount
+    );
+  });
+
+  it("should revert batch node extension with invalid arrays", async function () {
+    const escrowAddress = await setupUserWithEscrow(user, oracle);
+    const CspEscrow = await ethers.getContractFactory("CspEscrow");
+    const cspEscrow: CspEscrow = CspEscrow.attach(escrowAddress) as CspEscrow;
+
+    await expect(
+      cspEscrow.connect(user).extendJobsNodesBatch([], [])
+    ).to.be.revertedWith("No jobs provided");
+
+    await expect(
+      cspEscrow.connect(user).extendJobsNodesBatch([1n], [2n, 3n])
+    ).to.be.revertedWith("Array length mismatch");
+  });
+
+  it("should revert batch node extension when caller is not the CSP owner", async function () {
+    const escrowAddress = await setupUserWithEscrow(user, oracle);
+    const CspEscrow = await ethers.getContractFactory("CspEscrow");
+    const cspEscrow: CspEscrow = CspEscrow.attach(escrowAddress) as CspEscrow;
+
+    await expect(
+      cspEscrow.connect(other).extendJobsNodesBatch([1n], [2n])
+    ).to.be.revertedWith("Not authorized");
+  });
+
   it("should revert when extending nodes for a non-existent job", async function () {
     const escrowAddress = await setupUserWithEscrow(user, oracle);
     const CspEscrow = await ethers.getContractFactory("CspEscrow");


### PR DESCRIPTION
## Summary
- add `extendJobsDurationBatch(jobIds, newLastExecutionEpochs)` to `CspEscrow`
- perform a single USDC `transferFrom` for all extended jobs in the batch
- emit `JobDurationExtended` for each updated job
- add Hardhat coverage for multi-job single-transaction extend

## Validation
- npm run test -- --grep "extend multiple jobs duration in a single transaction"
- npm run build
