### PR TITLE
Use packed availabilities for rewards claims

### DIFF
--- a/contracts/MNDContract.sol
+++ b/contracts/MNDContract.sol
@@ -36,8 +36,9 @@ interface IAdoptionOracle {
 struct ComputeRewardsParams {
     uint256 licenseId;
     address nodeAddress;
-    uint256[] epochs;
-    uint8[] availabilies;
+    uint256 fromEpoch;
+    uint256 toEpoch;
+    bytes packedAvailabilities;
 }
 
 struct ComputeRewardsResult {
@@ -390,7 +391,7 @@ contract MNDContract is
                     state.licenseRewards,
                     state.licenseCarryover,
                     state.withheldAmount,
-                    computeParams[i].epochs.length
+                    computeParams[i].packedAvailabilities.length
                 );
                 if (computeParams[i].licenseId == GENESIS_TOKEN_ID) {
                     mintCompanyFunds(totalRewardsToMint);
@@ -498,15 +499,14 @@ contract MNDContract is
             .getAdoptionPercentagesRange(firstEpochToClaim, currentEpoch - 1);
 
         if (
-            computeParam.epochs.length != epochsToClaim ||
-            (computeParam.availabilies.length != epochsToClaim &&
-                adoptionPercentages.length != epochsToClaim)
+            computeParam.packedAvailabilities.length != epochsToClaim ||
+            adoptionPercentages.length != epochsToClaim
         ) {
             revert IncorrectNumberOfParams();
         }
         if (
-            computeParam.epochs[computeParam.epochs.length - 1] !=
-            currentEpoch - 1
+            computeParam.fromEpoch != firstEpochToClaim ||
+            computeParam.toEpoch != currentEpoch - 1
         ) {
             revert InvalidEpochs();
         }
@@ -517,12 +517,12 @@ contract MNDContract is
                 license.totalAssignedAmount /
                 _controller.GND_MINING_EPOCHS();
         }
-        for (uint256 i = 0; i < computeParam.epochs.length; i++) {
+        for (uint256 i = 0; i < computeParam.packedAvailabilities.length; i++) {
             // Gather data for epoch reward calculation
             uint256 epochMaxRelease = computeParam.licenseId == GENESIS_TOKEN_ID
                 ? maxRewardsPerEpochGnd
                 : calculateMndEpochRelease(
-                    computeParam.epochs[i],
+                    computeParam.fromEpoch + i,
                     license.firstMiningEpoch,
                     state.licensePlateau
                 );
@@ -534,7 +534,7 @@ contract MNDContract is
                     state.totalClaimedAmount,
                     state.totalAssignedAmount,
                     epochMaxRelease,
-                    computeParam.availabilies[i],
+                    uint8(computeParam.packedAvailabilities[i]),
                     adoptionPercentages[i]
                 );
 
@@ -864,8 +864,9 @@ contract MNDContract is
         bytes32 messageHash = keccak256(
             abi.encodePacked(
                 computeParam.nodeAddress,
-                computeParam.epochs,
-                computeParam.availabilies
+                computeParam.fromEpoch,
+                computeParam.toEpoch,
+                computeParam.packedAvailabilities
             )
         );
         bytes32 ethSignedMessageHash = MessageHashUtils.toEthSignedMessageHash(

--- a/contracts/NDContract.sol
+++ b/contracts/NDContract.sol
@@ -32,8 +32,9 @@ interface IAdoptionOracle {
 struct ComputeRewardsParams {
     uint256 licenseId;
     address nodeAddress;
-    uint256[] epochs;
-    uint8[] availabilies;
+    uint256 fromEpoch;
+    uint256 toEpoch;
+    bytes packedAvailabilities;
 }
 
 struct ComputeRewardsResult {
@@ -508,7 +509,7 @@ contract NDContract is
                     msg.sender,
                     computeParams[i].licenseId,
                     rewardsAmount,
-                    computeParams[i].epochs.length
+                    computeParams[i].packedAvailabilities.length
                 );
             }
         }
@@ -561,14 +562,13 @@ contract NDContract is
         }
 
         if (
-            computeParam.epochs.length != epochsToClaim ||
-            computeParam.availabilies.length != epochsToClaim
+            computeParam.packedAvailabilities.length != epochsToClaim
         ) {
             revert IncorrectNumberOfParams();
         }
         if (
-            computeParam.epochs[computeParam.epochs.length - 1] !=
-            currentEpoch - 1
+            computeParam.fromEpoch != license.lastClaimEpoch ||
+            computeParam.toEpoch != currentEpoch - 1
         ) {
             revert InvalidEpochs();
         }
@@ -576,7 +576,8 @@ contract NDContract is
         uint256 maxReleasePerDay = _controller.ND_MAX_RELEASE_PER_DAY();
         for (uint256 i = 0; i < epochsToClaim; i++) {
             licenseRewards +=
-                (maxReleasePerDay * computeParam.availabilies[i]) /
+                (maxReleasePerDay *
+                    uint8(computeParam.packedAvailabilities[i])) /
                 MAX_AVAILABILITY;
         }
 
@@ -980,8 +981,9 @@ contract NDContract is
         bytes32 messageHash = keccak256(
             abi.encodePacked(
                 computeParam.nodeAddress,
-                computeParam.epochs,
-                computeParam.availabilies
+                computeParam.fromEpoch,
+                computeParam.toEpoch,
+                computeParam.packedAvailabilities
             )
         );
         bytes32 ethSignedMessageHash = MessageHashUtils.toEthSignedMessageHash(

--- a/test/MNDContract.test.ts
+++ b/test/MNDContract.test.ts
@@ -14,6 +14,7 @@ import {
   revertSnapshotAndCapture,
   setTimestampAndMine,
   signComputeParams,
+  packedComputeParams,
   signLinkMultiNode,
   signLinkNode,
   START_EPOCH_TIMESTAMP,
@@ -883,7 +884,7 @@ describe("MNDContract", function () {
     await ethers.provider.send("evm_mine", []);
 
     //DO TEST
-    let result = await mndContract.calculateRewards([COMPUTE_PARAMS]);
+    let result = await mndContract.calculateRewards([packedComputeParams(COMPUTE_PARAMS)]);
     expect({
       licenseId: result[0].licenseId,
       rewardsAmount: result[0].rewardsAmount,
@@ -904,12 +905,12 @@ describe("MNDContract", function () {
 
     //DO TEST
     let result = await mndContract.calculateRewards([
-      {
+      packedComputeParams({
         licenseId: 2,
         nodeAddress: NODE_ADDRESS,
         epochs: [223],
         availabilies: [255],
-      },
+      }),
     ]);
     expect({
       licenseId: result[0].licenseId,
@@ -954,7 +955,7 @@ describe("MNDContract", function () {
     await mndContract
       .connect(firstUser)
       .claimRewards(
-        [zeroAdoptionParams],
+        [packedComputeParams(zeroAdoptionParams)],
         [[ethers.getBytes(zeroAdoptionSignature)]]
       );
 
@@ -1000,7 +1001,7 @@ describe("MNDContract", function () {
     });
     await mndContract
       .connect(firstUser)
-      .claimRewards([params], [[ethers.getBytes(paramsSignature)]]);
+      .claimRewards([packedComputeParams(params)], [[ethers.getBytes(paramsSignature)]]);
 
     const awbBalance = await mndContract.awbBalances(2);
     const license = await mndContract.licenses(2);
@@ -1053,7 +1054,7 @@ describe("MNDContract", function () {
     });
     await mndContract
       .connect(firstUser)
-      .claimRewards([epochOneParams], [[ethers.getBytes(epochOneSignature)]]);
+      .claimRewards([packedComputeParams(epochOneParams)], [[ethers.getBytes(epochOneSignature)]]);
 
     const awbAfterFirst = await mndContract.awbBalances(2);
     expect(awbAfterFirst).to.equal(0n);
@@ -1090,7 +1091,7 @@ describe("MNDContract", function () {
     const licenseBeforeSecond = await mndContract.licenses(2);
     await mndContract
       .connect(firstUser)
-      .claimRewards([epochTwoParams], [[ethers.getBytes(epochTwoSignature)]]);
+      .claimRewards([packedComputeParams(epochTwoParams)], [[ethers.getBytes(epochTwoSignature)]]);
     const mintedAfterSecond = await r1Contract.balanceOf(
       await firstUser.getAddress()
     );
@@ -1154,7 +1155,7 @@ describe("MNDContract", function () {
     });
     await mndContract
       .connect(firstUser)
-      .claimRewards([epochOneParams], [[ethers.getBytes(epochOneSignature)]]);
+      .claimRewards([packedComputeParams(epochOneParams)], [[ethers.getBytes(epochOneSignature)]]);
 
     const adoptionPercentEpochOne =
       await adoptionOracleOverride.getAdoptionPercentageAtEpoch(epochOne);
@@ -1193,7 +1194,7 @@ describe("MNDContract", function () {
     const licenseBeforeSecond = await mndContract.licenses(2);
     await mndContract
       .connect(firstUser)
-      .claimRewards([epochTwoParams], [[ethers.getBytes(epochTwoSignature)]]);
+      .claimRewards([packedComputeParams(epochTwoParams)], [[ethers.getBytes(epochTwoSignature)]]);
     const mintedAfterSecond = await r1Contract.balanceOf(
       await firstUser.getAddress()
     );
@@ -1260,7 +1261,7 @@ describe("MNDContract", function () {
     });
     await mndContract
       .connect(firstUser)
-      .claimRewards([params], [[ethers.getBytes(signature)]]);
+      .claimRewards([packedComputeParams(params)], [[ethers.getBytes(signature)]]);
 
     const minted = await r1Contract.balanceOf(await firstUser.getAddress());
     const license = await mndContract.licenses(2);
@@ -1306,7 +1307,7 @@ describe("MNDContract", function () {
     });
     await mndContract
       .connect(firstUser)
-      .claimRewards([params], [[ethers.getBytes(signature)]]);
+      .claimRewards([packedComputeParams(params)], [[ethers.getBytes(signature)]]);
 
     const minted = await r1Contract.balanceOf(await firstUser.getAddress());
     const license = await mndContract.licenses(2);
@@ -1354,7 +1355,7 @@ describe("MNDContract", function () {
     });
     await mndContract
       .connect(firstUser)
-      .claimRewards([epochOneParams], [[ethers.getBytes(epochOneSignature)]]);
+      .claimRewards([packedComputeParams(epochOneParams)], [[ethers.getBytes(epochOneSignature)]]);
 
     const licenseAfterFirst = await mndContract.licenses(2);
     const awbAfterFirst = await mndContract.awbBalances(2);
@@ -1380,7 +1381,7 @@ describe("MNDContract", function () {
     });
     await mndContract
       .connect(firstUser)
-      .claimRewards([epochTwoParams], [[ethers.getBytes(epochTwoSignature)]]);
+      .claimRewards([packedComputeParams(epochTwoParams)], [[ethers.getBytes(epochTwoSignature)]]);
 
     const mintedAfterSecond = await r1Contract.balanceOf(
       await firstUser.getAddress()
@@ -1434,7 +1435,7 @@ describe("MNDContract", function () {
     });
     await mndContract
       .connect(firstUser)
-      .claimRewards([epochOneParams], [[ethers.getBytes(epochOneSignature)]]);
+      .claimRewards([packedComputeParams(epochOneParams)], [[ethers.getBytes(epochOneSignature)]]);
 
     const awbAfterFirst = await mndContract.awbBalances(2);
     const licenseAfterFirst = await mndContract.licenses(2);
@@ -1460,7 +1461,7 @@ describe("MNDContract", function () {
     });
     await mndContract
       .connect(firstUser)
-      .claimRewards([epochTwoParams], [[ethers.getBytes(epochTwoSignature)]]);
+      .claimRewards([packedComputeParams(epochTwoParams)], [[ethers.getBytes(epochTwoSignature)]]);
 
     const mintedAfterSecond = await r1Contract.balanceOf(
       await firstUser.getAddress()
@@ -1521,7 +1522,7 @@ describe("MNDContract", function () {
     });
     await mndContract
       .connect(firstUser)
-      .claimRewards([buildParams], [[ethers.getBytes(buildSignature)]]);
+      .claimRewards([packedComputeParams(buildParams)], [[ethers.getBytes(buildSignature)]]);
 
     const awbAfterBuild = await mndContract.awbBalances(2);
     expect(awbAfterBuild).to.be.gt(0n);
@@ -1547,7 +1548,7 @@ describe("MNDContract", function () {
     const licenseBeforeJump = await mndContract.licenses(2);
     await mndContract
       .connect(firstUser)
-      .claimRewards([epochJumpParams], [[ethers.getBytes(epochJumpSignature)]]);
+      .claimRewards([packedComputeParams(epochJumpParams)], [[ethers.getBytes(epochJumpSignature)]]);
     const mintedAfterJump = await r1Contract.balanceOf(
       await firstUser.getAddress()
     );
@@ -1582,7 +1583,7 @@ describe("MNDContract", function () {
     const licenseBeforeNext = await mndContract.licenses(2);
     await mndContract
       .connect(firstUser)
-      .claimRewards([epochNextParams], [[ethers.getBytes(epochNextSignature)]]);
+      .claimRewards([packedComputeParams(epochNextParams)], [[ethers.getBytes(epochNextSignature)]]);
     const mintedAfterNext = await r1Contract.balanceOf(
       await firstUser.getAddress()
     );
@@ -1641,7 +1642,7 @@ describe("MNDContract", function () {
     });
     await mndContract
       .connect(firstUser)
-      .claimRewards([earlyParams], [[ethers.getBytes(earlySignature)]]);
+      .claimRewards([packedComputeParams(earlyParams)], [[ethers.getBytes(earlySignature)]]);
 
     const awbAfterEarly = await mndContract.awbBalances(2);
     const licenseAfterEarly = await mndContract.licenses(2);
@@ -1668,7 +1669,7 @@ describe("MNDContract", function () {
     });
     await mndContract
       .connect(firstUser)
-      .claimRewards([plateauParams], [[ethers.getBytes(plateauSignature)]]);
+      .claimRewards([packedComputeParams(plateauParams)], [[ethers.getBytes(plateauSignature)]]);
 
     const mintedAfterPlateau = await r1Contract.balanceOf(
       await firstUser.getAddress()
@@ -1699,7 +1700,7 @@ describe("MNDContract", function () {
     await mndContract
       .connect(firstUser)
       .claimRewards(
-        [plateauNextParams],
+        [packedComputeParams(plateauNextParams)],
         [[ethers.getBytes(plateauNextSignature)]]
       );
 
@@ -1784,7 +1785,7 @@ describe("MNDContract", function () {
     });
     await mndContract
       .connect(firstUser)
-      .claimRewards([epochOneParams], [[ethers.getBytes(epochOneSignature)]]);
+      .claimRewards([packedComputeParams(epochOneParams)], [[ethers.getBytes(epochOneSignature)]]);
 
     const balanceAfterFirst = await r1Contract.balanceOf(
       await firstUser.getAddress()
@@ -1818,7 +1819,7 @@ describe("MNDContract", function () {
     });
     await mndContract
       .connect(firstUser)
-      .claimRewards([epochTwoParams], [[ethers.getBytes(epochTwoSignature)]]);
+      .claimRewards([packedComputeParams(epochTwoParams)], [[ethers.getBytes(epochTwoSignature)]]);
 
     const balanceAfterSecond = await r1Contract.balanceOf(
       await firstUser.getAddress()
@@ -1870,7 +1871,7 @@ describe("MNDContract", function () {
     //DO TEST
     await mndContract
       .connect(firstUser)
-      .claimRewards([COMPUTE_PARAMS], [[await computeSignatureBytes(oracle)]]);
+      .claimRewards([packedComputeParams(COMPUTE_PARAMS)], [[await computeSignatureBytes(oracle)]]);
     expect(await r1Contract.balanceOf(await firstUser.getAddress())).to.equal(
       REWARDS_AMOUNT
     );
@@ -1899,7 +1900,7 @@ describe("MNDContract", function () {
     //DO TEST
     await mndContract
       .connect(owner)
-      .claimRewards([COMPUTE_PARAMS], [[await computeSignatureBytes(oracle)]]);
+      .claimRewards([packedComputeParams(COMPUTE_PARAMS)], [[await computeSignatureBytes(oracle)]]);
     expect(await r1Contract.balanceOf(newLpWallet)).to.equal(
       76489386831087123287670n
     );
@@ -1931,14 +1932,14 @@ describe("MNDContract", function () {
     //DO TEST
     await mndContract
       .connect(firstUser)
-      .claimRewards([COMPUTE_PARAMS], [[await computeSignatureBytes(oracle)]]);
+      .claimRewards([packedComputeParams(COMPUTE_PARAMS)], [[await computeSignatureBytes(oracle)]]);
     expect(await r1Contract.balanceOf(await firstUser.getAddress())).to.equal(
       REWARDS_AMOUNT
     );
     //should not modify amount
     await mndContract
       .connect(firstUser)
-      .claimRewards([COMPUTE_PARAMS], [[await computeSignatureBytes(oracle)]]);
+      .claimRewards([packedComputeParams(COMPUTE_PARAMS)], [[await computeSignatureBytes(oracle)]]);
     expect(await r1Contract.balanceOf(await firstUser.getAddress())).to.equal(
       REWARDS_AMOUNT
     );
@@ -1956,7 +1957,7 @@ describe("MNDContract", function () {
     //DO TEST - should not claim anything
     await mndContract
       .connect(firstUser)
-      .claimRewards([COMPUTE_PARAMS], [[await computeSignatureBytes(oracle)]]);
+      .claimRewards([packedComputeParams(COMPUTE_PARAMS)], [[await computeSignatureBytes(oracle)]]);
     expect(await r1Contract.balanceOf(await firstUser.getAddress())).to.equal(
       0n
     );
@@ -1984,7 +1985,10 @@ describe("MNDContract", function () {
     );
     await mndContract
       .connect(firstUser)
-      .claimRewards([COMPUTE_PARAMS], [[await computeSignatureBytes(oracle)]]);
+      .claimRewards(
+        [packedComputeParams(COMPUTE_PARAMS)],
+        [[await computeSignatureBytes(oracle)]]
+      );
     expect(await r1Contract.balanceOf(await firstUser.getAddress())).to.equal(
       LICENSE_POWER
     );
@@ -1996,7 +2000,7 @@ describe("MNDContract", function () {
     await ethers.provider.send("evm_mine", []);
     await mndContract
       .connect(firstUser)
-      .claimRewards([COMPUTE_PARAMS], [[await computeSignatureBytes(oracle)]]);
+      .claimRewards([packedComputeParams(COMPUTE_PARAMS)], [[await computeSignatureBytes(oracle)]]);
     expect(await r1Contract.balanceOf(await firstUser.getAddress())).to.equal(
       LICENSE_POWER //should not be changed
     );
@@ -2017,7 +2021,7 @@ describe("MNDContract", function () {
     await expect(
       mndContract
         .connect(secondUser)
-        .claimRewards([COMPUTE_PARAMS], [[await computeSignatureBytes(oracle)]])
+        .claimRewards([packedComputeParams(COMPUTE_PARAMS)], [[await computeSignatureBytes(oracle)]])
     ).to.be.revertedWithCustomError(mndContract, "NotLicenseOwner");
   });
 
@@ -2037,7 +2041,7 @@ describe("MNDContract", function () {
       mndContract
         .connect(firstUser)
         .claimRewards(
-          [COMPUTE_PARAMS],
+          [packedComputeParams(COMPUTE_PARAMS)],
           [[await computeSignatureBytes(firstUser)]]
         )
     ).to.be.revertedWith("Invalid oracle signature");
@@ -2059,7 +2063,7 @@ describe("MNDContract", function () {
     await expect(
       mndContract
         .connect(firstUser)
-        .claimRewards([COMPUTE_PARAMS], [[await computeSignatureBytes(oracle)]])
+        .claimRewards([packedComputeParams(COMPUTE_PARAMS)], [[await computeSignatureBytes(oracle)]])
     ).to.be.revertedWithCustomError(
       mndContract,
       "InvalidNodeAddressForRewards"
@@ -2076,12 +2080,19 @@ describe("MNDContract", function () {
       ONE_DAY_IN_SECS * (Number(CLIFF_PERIOD) + 5),
     ]);
     await ethers.provider.send("evm_mine", []);
-    COMPUTE_PARAMS.epochs = [1, 2, 3, 4, 5, 6, 7, 8];
+    COMPUTE_PARAMS.epochs = [
+      Number(CLIFF_PERIOD),
+      Number(CLIFF_PERIOD) + 1,
+      Number(CLIFF_PERIOD) + 2,
+      Number(CLIFF_PERIOD) + 3,
+      Number(CLIFF_PERIOD) + 4,
+    ];
+    COMPUTE_PARAMS.availabilies = [255, 255, 255, 255];
     //DO TEST
     await expect(
       mndContract
         .connect(firstUser)
-        .claimRewards([COMPUTE_PARAMS], [[await computeSignatureBytes(oracle)]])
+        .claimRewards([packedComputeParams(COMPUTE_PARAMS)], [[await computeSignatureBytes(oracle)]])
     ).to.be.revertedWithCustomError(mndContract, "IncorrectNumberOfParams");
   });
 
@@ -2112,7 +2123,7 @@ describe("MNDContract", function () {
     await mndContract
       .connect(firstUser)
       .claimRewards(
-        [COMPUTE_PARAMS],
+        [packedComputeParams(COMPUTE_PARAMS)],
         [
           [
             await computeSignatureBytes(oracle1),
@@ -2164,7 +2175,7 @@ describe("MNDContract", function () {
     //DO TEST
     await mndContract
       .connect(firstUser)
-      .claimRewards([COMPUTE_PARAMS], [[await computeSignatureBytes(oracle)]]);
+      .claimRewards([packedComputeParams(COMPUTE_PARAMS)], [[await computeSignatureBytes(oracle)]]);
     expect(await r1Contract.balanceOf(await firstUser.getAddress())).to.equal(
       REWARDS_AMOUNT
     );
@@ -2185,7 +2196,7 @@ describe("MNDContract", function () {
     await expect(
       mndContract
         .connect(firstUser)
-        .claimRewards([COMPUTE_PARAMS], [[await computeSignatureBytes(oracle)]])
+        .claimRewards([packedComputeParams(COMPUTE_PARAMS)], [[await computeSignatureBytes(oracle)]])
     ).to.be.revertedWith("Insufficient signatures");
   });
 

--- a/test/NDContract.test.ts
+++ b/test/NDContract.test.ts
@@ -17,6 +17,7 @@ import {
   setTimestampAndMine,
   signBuyLicense,
   signComputeParams,
+  packedComputeParams,
   signLinkMultiNode,
   signLinkNode,
   START_EPOCH_TIMESTAMP,
@@ -1149,7 +1150,7 @@ describe("NDContract", function () {
     //DO TEST
     let result = await ndContract
       .connect(owner)
-      .calculateRewards([COMPUTE_PARAMS]);
+      .calculateRewards([packedComputeParams(COMPUTE_PARAMS)]);
     const formattedResults = result.map(formatRewardsResult);
     expect(formattedResults[0]).to.deep.equal(EXPECTED_COMPUTE_REWARDS_RESULT);
   });
@@ -1180,7 +1181,7 @@ describe("NDContract", function () {
     );
     await ndContract
       .connect(firstUser)
-      .claimRewards([COMPUTE_PARAMS], [[await computeSignatureBytes(backend)]]);
+      .claimRewards([packedComputeParams(COMPUTE_PARAMS)], [[await computeSignatureBytes(backend)]]);
     expect(await r1Contract.balanceOf(await firstUser.getAddress())).to.equal(
       REWARDS_AMOUNT + userPreviousBalance
     );
@@ -1221,21 +1222,24 @@ describe("NDContract", function () {
     let userPreviousBalance = await r1Contract.balanceOf(
       await firstUser.getAddress()
     );
-    await ndContract.connect(firstUser).claimRewards(
-      [
-        {
-          licenseId: 1,
-          nodeAddress,
-          epochs: [1, 2, 3, 4, 5],
-          availabilies: [0, 0, 0, 0, 0],
-        },
-      ],
-      [
-        [
-          "0xc17b67684afb68fe25fb7ba6ec7fdf08c4d5fc8970ab03a7b3659a20d5df620314cb35b90deddff9cbc13668cc964e13816be73f308402e9903dae422106ca5d1c",
-        ],
-      ]
-    );
+    const zeroAvailabilityParams = {
+      licenseId: 1,
+      nodeAddress,
+      epochs: [1, 2, 3, 4, 5],
+      availabilies: [0, 0, 0, 0, 0],
+    };
+    const zeroAvailabilitySignature = await signComputeParams({
+      signer: backend,
+      nodeAddress,
+      epochs: zeroAvailabilityParams.epochs,
+      availabilities: zeroAvailabilityParams.availabilies,
+    });
+    await ndContract
+      .connect(firstUser)
+      .claimRewards(
+        [packedComputeParams(zeroAvailabilityParams)],
+        [[ethers.getBytes(zeroAvailabilitySignature)]]
+      );
     expect(await r1Contract.balanceOf(await firstUser.getAddress())).to.equal(
       userPreviousBalance
     );
@@ -1266,7 +1270,10 @@ describe("NDContract", function () {
       ndContract
         .connect(firstUser)
         .claimRewards(
-          [COMPUTE_PARAMS, COMPUTE_PARAMS],
+          [
+            packedComputeParams(COMPUTE_PARAMS),
+            packedComputeParams(COMPUTE_PARAMS),
+          ],
           [[await computeSignatureBytes(backend)]]
         )
     ).to.be.revertedWithCustomError(ndContract, "MismatchedInputArraysLength");
@@ -1295,7 +1302,7 @@ describe("NDContract", function () {
       ndContract
         .connect(secondUser)
         .claimRewards(
-          [COMPUTE_PARAMS],
+          [packedComputeParams(COMPUTE_PARAMS)],
           [[await computeSignatureBytes(backend)]]
         )
     ).to.be.revertedWithCustomError(ndContract, "NotLicenseOwner");
@@ -1324,7 +1331,7 @@ describe("NDContract", function () {
       ndContract
         .connect(firstUser)
         .claimRewards(
-          [COMPUTE_PARAMS],
+          [packedComputeParams(COMPUTE_PARAMS)],
           [[await computeSignatureBytes(secondUser)]]
         )
     ).to.be.revertedWith("Invalid oracle signature");
@@ -1354,7 +1361,7 @@ describe("NDContract", function () {
       ndContract
         .connect(firstUser)
         .claimRewards(
-          [COMPUTE_PARAMS],
+          [packedComputeParams(COMPUTE_PARAMS)],
           [
             [
               await computeSignatureBytes(backend),
@@ -1394,7 +1401,7 @@ describe("NDContract", function () {
     await ndContract
       .connect(firstUser)
       .claimRewards(
-        [COMPUTE_PARAMS],
+        [packedComputeParams(COMPUTE_PARAMS)],
         [
           [
             await computeSignatureBytes(backend),
@@ -1431,7 +1438,7 @@ describe("NDContract", function () {
       ndContract
         .connect(firstUser)
         .claimRewards(
-          [COMPUTE_PARAMS],
+          [packedComputeParams(COMPUTE_PARAMS)],
           [[await computeSignatureBytes(backend)]]
         )
     ).to.be.revertedWith("Insufficient signatures");
@@ -1461,7 +1468,7 @@ describe("NDContract", function () {
       ndContract
         .connect(firstUser)
         .claimRewards(
-          [COMPUTE_PARAMS],
+          [packedComputeParams(COMPUTE_PARAMS)],
           [[await computeSignatureBytes(backend)]]
         )
     ).to.be.revertedWithCustomError(ndContract, "InvalidNodeAddressForRewards");
@@ -1485,13 +1492,14 @@ describe("NDContract", function () {
     await ethers.provider.send("evm_increaseTime", [ONE_DAY_IN_SECS * 5]);
     await ethers.provider.send("evm_mine", []);
 
-    COMPUTE_PARAMS.epochs = [1, 2, 3, 4, 5, 6, 7, 8];
+    COMPUTE_PARAMS.epochs = [0, 1, 2, 3, 4];
+    COMPUTE_PARAMS.availabilies = [255, 255, 255, 255];
     //DO TEST
     await expect(
       ndContract
         .connect(firstUser)
         .claimRewards(
-          [COMPUTE_PARAMS],
+          [packedComputeParams(COMPUTE_PARAMS)],
           [[await computeSignatureBytes(backend)]]
         )
     ).to.be.revertedWithCustomError(ndContract, "IncorrectNumberOfParams");
@@ -1523,14 +1531,14 @@ describe("NDContract", function () {
     );
     await ndContract
       .connect(firstUser)
-      .claimRewards([COMPUTE_PARAMS], [[await computeSignatureBytes(backend)]]);
+      .claimRewards([packedComputeParams(COMPUTE_PARAMS)], [[await computeSignatureBytes(backend)]]);
     expect(await r1Contract.balanceOf(await firstUser.getAddress())).to.equal(
       REWARDS_AMOUNT + userPreviousBalance
     );
     //should not modify amount
     await ndContract
       .connect(firstUser)
-      .claimRewards([COMPUTE_PARAMS], [[await computeSignatureBytes(backend)]]);
+      .claimRewards([packedComputeParams(COMPUTE_PARAMS)], [[await computeSignatureBytes(backend)]]);
     expect(await r1Contract.balanceOf(await firstUser.getAddress())).to.equal(
       REWARDS_AMOUNT + userPreviousBalance
     );
@@ -1568,7 +1576,7 @@ describe("NDContract", function () {
     );
     await ndContract
       .connect(firstUser)
-      .claimRewards([COMPUTE_PARAMS], [[await computeSignatureBytes(backend)]]);
+      .claimRewards([packedComputeParams(COMPUTE_PARAMS)], [[await computeSignatureBytes(backend)]]);
     expect(await r1Contract.balanceOf(await firstUser.getAddress())).to.equal(
       expected_result + userPreviousBalance
     );
@@ -1582,7 +1590,7 @@ describe("NDContract", function () {
     await ethers.provider.send("evm_mine", []);
     await ndContract
       .connect(firstUser)
-      .claimRewards([COMPUTE_PARAMS], [[await computeSignatureBytes(backend)]]);
+      .claimRewards([packedComputeParams(COMPUTE_PARAMS)], [[await computeSignatureBytes(backend)]]);
     expect(await r1Contract.balanceOf(await firstUser.getAddress())).to.equal(
       expected_result + userPreviousBalance //should not be changed
     );
@@ -1627,7 +1635,7 @@ describe("NDContract", function () {
     await ndContract
       .connect(firstUser)
       .claimRewards(
-        [COMPUTE_PARAMS],
+        [packedComputeParams(COMPUTE_PARAMS)],
         [
           [
             await computeSignatureBytes(oracle1),
@@ -1749,7 +1757,7 @@ describe("NDContract", function () {
       ndContract
         .connect(firstUser)
         .claimRewards(
-          [COMPUTE_PARAMS],
+          [packedComputeParams(COMPUTE_PARAMS)],
           [[await computeSignatureBytes(backend)]]
         )
     ).to.be.revertedWithCustomError(ndContract, "LicenseBanned");
@@ -1805,14 +1813,14 @@ describe("NDContract", function () {
       ndContract
         .connect(firstUser)
         .claimRewards(
-          [COMPUTE_PARAMS],
+          [packedComputeParams(COMPUTE_PARAMS)],
           [[await computeSignatureBytes(backend)]]
         )
     ).to.be.revertedWithCustomError(ndContract, "LicenseBanned");
     await ndContract.connect(owner).unbanLicense(1);
     await ndContract
       .connect(firstUser)
-      .claimRewards([COMPUTE_PARAMS], [[await computeSignatureBytes(backend)]]);
+      .claimRewards([packedComputeParams(COMPUTE_PARAMS)], [[await computeSignatureBytes(backend)]]);
   });
 
   it("Unban license - not the owner", async function () {

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -420,26 +420,23 @@ export async function signComputeParams({
   epochs: BigNumberish[];
   availabilities: BigNumberish[];
 }): Promise<string> {
+  const fromEpoch = epochs[0] ?? 0;
+  const toEpoch = epochs[epochs.length - 1] ?? 0;
+  const packedAvailabilities = packAvailabilities(availabilities);
   let messageBytes = Buffer.from(nodeAddress.slice(2), "hex");
 
-  for (const epoch of epochs) {
-    const epochBytes = ethers.zeroPadValue(ethers.toBeHex(epoch), 32);
+  for (const value of [fromEpoch, toEpoch]) {
+    const valueBytes = ethers.zeroPadValue(ethers.toBeHex(value), 32);
     messageBytes = Buffer.concat([
       messageBytes,
-      Buffer.from(epochBytes.slice(2), "hex"),
+      Buffer.from(valueBytes.slice(2), "hex"),
     ]);
   }
 
-  for (const availability of availabilities) {
-    const availabilityBytes = ethers.zeroPadValue(
-      ethers.toBeHex(availability),
-      32
-    );
-    messageBytes = Buffer.concat([
-      messageBytes,
-      Buffer.from(availabilityBytes.slice(2), "hex"),
-    ]);
-  }
+  messageBytes = Buffer.concat([
+    messageBytes,
+    Buffer.from(packedAvailabilities.slice(2), "hex"),
+  ]);
 
   const messageHash = ethers.keccak256(messageBytes);
   const signature = await signer.signMessage(ethers.getBytes(messageHash));
@@ -450,6 +447,34 @@ export async function signComputeParams({
   }
 
   return ethers.hexlify(signatureBytes);
+}
+
+export function packAvailabilities(availabilities: BigNumberish[]): string {
+  const bytes = availabilities.map((availability) => {
+    const value = BigInt(availability);
+    if (value < 0n || value > 255n) {
+      throw new Error(`Invalid availability ${availability}`);
+    }
+    return Number(value);
+  });
+  return ethers.hexlify(Uint8Array.from(bytes));
+}
+
+export function packedComputeParams<
+  T extends {
+    licenseId: BigNumberish;
+    nodeAddress: string;
+    epochs: BigNumberish[];
+    availabilies: BigNumberish[];
+  },
+>(params: T) {
+  return {
+    licenseId: params.licenseId,
+    nodeAddress: params.nodeAddress,
+    fromEpoch: params.epochs[0] ?? 0,
+    toEpoch: params.epochs[params.epochs.length - 1] ?? 0,
+    packedAvailabilities: packAvailabilities(params.availabilies),
+  };
 }
 
 export async function deployUniswapMocks(r1: R1): Promise<{


### PR DESCRIPTION
## Summary
- Replace ND/MND claim params with fromEpoch, toEpoch, and packedAvailabilities.
- Verify signatures over nodeAddress, fromEpoch, toEpoch, and packedAvailabilities, excluding licenseId.
- Keep claims restricted to the full current claim window and update reward tests.

## Validation
- npx hardhat compile
- npx hardhat test test/NDContract.test.ts test/MNDContract.test.ts
- npm run test