### PR TITLE
Add CSP tier flag

### DIFF
--- a/contracts/CspEscrow.sol
+++ b/contracts/CspEscrow.sol
@@ -131,6 +131,7 @@ contract CspEscrow is Initializable {
     mapping(address => uint256) private delegatesPermissions;
     address[] private delegatedAddresses;
     IBurnContract public burnContract;
+    uint8 public cspTier;
 
     //.########.##.....##.########.##....##.########..######.
     //.##.......##.....##.##.......###...##....##....##....##
@@ -194,6 +195,7 @@ contract CspEscrow is Initializable {
         uint256 permissions
     );
     event DelegateRemoved(address indexed delegate);
+    event CspTierUpdated(uint8 previousTier, uint8 newTier);
 
     //.########.##....##.########..########...#######..####.##....##.########..######.
     //.##.......###...##.##.....##.##.....##.##.....##..##..###...##....##....##....##
@@ -745,6 +747,12 @@ contract CspEscrow is Initializable {
             "Burn contract cannot be zero address"
         );
         burnContract = IBurnContract(newBurnContract);
+    }
+
+    function setCspTier(uint8 newTier) external onlyPoAIManager {
+        uint8 previousTier = cspTier;
+        cspTier = newTier;
+        emit CspTierUpdated(previousTier, newTier);
     }
 
     function reconcileAllJobs() external onlyPoAIManager {

--- a/contracts/PoAIManager.sol
+++ b/contracts/PoAIManager.sol
@@ -106,6 +106,7 @@ error DelegateNotRegistered();
 error AlreadyReconciled();
 error TimestampBeforeStartEpoch();
 error NotCspEscrow();
+error CspEscrowDoesNotExist();
 
 contract PoAIManager is Initializable, OwnableUpgradeable {
     //..######..########..#######..########.....###.....######...########
@@ -208,6 +209,11 @@ contract PoAIManager is Initializable, OwnableUpgradeable {
         address indexed escrow,
         uint256 amount
     );
+    event CspTierUpdated(
+        address indexed cspOwner,
+        address indexed escrow,
+        uint8 newTier
+    );
 
     //.########.##....##.########..########...#######..####.##....##.########..######.
     //.##.......###...##.##.....##.##.....##.##.....##..##..###...##....##....##....##
@@ -281,6 +287,16 @@ contract PoAIManager is Initializable, OwnableUpgradeable {
         for (uint256 i = 0; i < escrowCount; i++) {
             CspEscrow(allEscrows[i]).setBurnContract(newBurnContract);
         }
+    }
+
+    function setCspTier(address cspOwner, uint8 newTier) external onlyOwner {
+        address escrowAddress = ownerToEscrow[cspOwner];
+        if (escrowAddress == address(0)) {
+            revert CspEscrowDoesNotExist();
+        }
+
+        CspEscrow(escrowAddress).setCspTier(newTier);
+        emit CspTierUpdated(cspOwner, escrowAddress, newTier);
     }
 
     // Internal function to check if user owns at least one ND or MND with a linked node address that is an oracle
@@ -808,6 +824,18 @@ contract PoAIManager is Initializable, OwnableUpgradeable {
             return (true, delegatedEscrow);
         }
         return (false, address(0));
+    }
+
+    function getCspTier(address account) external view returns (uint8) {
+        address escrowAddress = ownerToEscrow[account];
+        if (escrowAddress == address(0)) {
+            escrowAddress = delegatedAddressToEscrow[account];
+        }
+        if (escrowAddress == address(0)) {
+            return 0;
+        }
+
+        return CspEscrow(escrowAddress).cspTier();
     }
 
     // Get all job IDs that have node updates submitted but no consensus reached yet that a specific oracle has not submitted yet

--- a/contracts/Reader.sol
+++ b/contracts/Reader.sol
@@ -176,6 +176,7 @@ interface IPoAIManager {
     function getAddressRegistration(
         address account
     ) external view returns (bool isActive, address escrowAddress);
+    function getCspTier(address account) external view returns (uint8);
 }
 
 interface ICspEscrow {
@@ -651,6 +652,10 @@ contract Reader is Initializable {
                 escrowOwner: escrowOwner,
                 permissions: permissions
             });
+    }
+
+    function getCspTier(address account) external view returns (uint8) {
+        return poaiManager.getCspTier(account);
     }
 
     function _isOracle(

--- a/test/PoAI.test.ts
+++ b/test/PoAI.test.ts
@@ -448,6 +448,97 @@ describe("PoAIManager", function () {
       );
   });
 
+  describe("CSP tiers", function () {
+    it("defaults newly deployed CSP escrow tier to zero", async function () {
+      const escrowAddress = await setupUserWithEscrow(user, oracle);
+      const cspEscrow = (await ethers.getContractAt(
+        "CspEscrow",
+        escrowAddress
+      )) as unknown as CspEscrow;
+
+      expect(await cspEscrow.cspTier()).to.equal(0);
+      expect(await poaiManager.getCspTier(await user.getAddress())).to.equal(0);
+    });
+
+    it("allows PoAI manager owner to update CSP tier", async function () {
+      const escrowAddress = await setupUserWithEscrow(user, oracle);
+      const userAddress = await user.getAddress();
+      const cspEscrow = (await ethers.getContractAt(
+        "CspEscrow",
+        escrowAddress
+      )) as unknown as CspEscrow;
+
+      await expect(poaiManager.connect(owner).setCspTier(userAddress, 1))
+        .to.emit(cspEscrow, "CspTierUpdated")
+        .withArgs(0, 1)
+        .and.to.emit(poaiManager, "CspTierUpdated")
+        .withArgs(userAddress, escrowAddress, 1);
+
+      expect(await cspEscrow.cspTier()).to.equal(1);
+      expect(await poaiManager.getCspTier(userAddress)).to.equal(1);
+
+      await poaiManager.connect(owner).setCspTier(userAddress, 2);
+
+      expect(await cspEscrow.cspTier()).to.equal(2);
+      expect(await poaiManager.getCspTier(userAddress)).to.equal(2);
+    });
+
+    it("prevents non-owner accounts from updating CSP tier", async function () {
+      await setupUserWithEscrow(user, oracle);
+
+      await expect(
+        poaiManager.connect(user).setCspTier(await user.getAddress(), 1)
+      ).to.be.revertedWithCustomError(
+        poaiManager,
+        "OwnableUnauthorizedAccount"
+      );
+    });
+
+    it("reverts when setting tier for an owner without escrow", async function () {
+      await expect(
+        poaiManager.connect(owner).setCspTier(await other.getAddress(), 1)
+      ).to.be.revertedWithCustomError(
+        poaiManager,
+        "CspEscrowDoesNotExist"
+      );
+    });
+
+    it("prevents direct escrow tier updates by non-manager accounts", async function () {
+      const escrowAddress = await setupUserWithEscrow(user, oracle);
+      const cspEscrow = (await ethers.getContractAt(
+        "CspEscrow",
+        escrowAddress
+      )) as unknown as CspEscrow;
+
+      await expect(cspEscrow.connect(user).setCspTier(1)).to.be.revertedWith(
+        "Not PoAI Manager"
+      );
+    });
+
+    it("returns delegated escrow tier for delegated addresses", async function () {
+      const escrowAddress = await setupUserWithEscrow(user, oracle);
+      const userAddress = await user.getAddress();
+      const delegateAddress = await other.getAddress();
+      const cspEscrow = (await ethers.getContractAt(
+        "CspEscrow",
+        escrowAddress
+      )) as unknown as CspEscrow;
+
+      await cspEscrow
+        .connect(user)
+        .setDelegatePermissions(delegateAddress, PERMISSION_CREATE_JOBS);
+      await poaiManager.connect(owner).setCspTier(userAddress, 2);
+
+      expect(await poaiManager.getCspTier(delegateAddress)).to.equal(2);
+    });
+
+    it("returns zero tier for unregistered addresses", async function () {
+      expect(await poaiManager.getCspTier(await other.getAddress())).to.equal(
+        0
+      );
+    });
+  });
+
   it("should allow CSP owner to create a job", async function () {
     const escrowAddress = await setupUserWithEscrow(user, oracle);
     const CspEscrow = await ethers.getContractFactory("CspEscrow");

--- a/test/Reader.test.ts
+++ b/test/Reader.test.ts
@@ -1030,6 +1030,43 @@ describe("Reader contract", function () {
     });
   });
 
+  describe("getCspTier", function () {
+    it("returns tier for owner, delegate, and unregistered account", async function () {
+      await buyLicenseWithMintAndAllowance(
+        r1Contract,
+        ndContract,
+        owner,
+        owner,
+        await ndContract.getLicenseTokenPrice(),
+        1,
+        1,
+        10000,
+        20,
+        await createLicenseSignature(backend, owner, invoiceUuid, 10000)
+      );
+      await linkNode(ndContract, owner, 1, await backend.getAddress());
+
+      await poaiManager.connect(owner).deployCspEscrow();
+      const escrowAddress = await poaiManager.ownerToEscrow(
+        await owner.getAddress()
+      );
+      const cspEscrow = (await ethers.getContractAt(
+        "CspEscrow",
+        escrowAddress
+      )) as unknown as CspEscrow;
+      const delegateAddress = await firstUser.getAddress();
+
+      await cspEscrow
+        .connect(owner)
+        .setDelegatePermissions(delegateAddress, PERMISSION_CREATE_JOBS);
+      await poaiManager.connect(owner).setCspTier(await owner.getAddress(), 2);
+
+      expect(await reader.getCspTier(await owner.getAddress())).to.equal(2);
+      expect(await reader.getCspTier(delegateAddress)).to.equal(2);
+      expect(await reader.getCspTier(await backend.getAddress())).to.equal(0);
+    });
+  });
+
   describe("getNdNodesOwners", function () {
     it("returns owners for ND nodes", async function () {
       await buyLicenseWithMintAndAllowance(


### PR DESCRIPTION
## Summary
- Add a per-CSP `uint8` tier flag on `CspEscrow`.
- Add owner-only `PoAIManager.setCspTier(cspOwner, tier)` and `getCspTier(account)` lookup for owners and delegated addresses.
- Add `Reader.getCspTier(account)` and tests covering owner, delegate, and unregistered reads.

## Validation
- `npm run build`
- `npx hardhat test test/PoAI.test.ts`
- `npx hardhat test test/Reader.test.ts`
- `npm run test`