### PR TITLE
[codex] Include CSP tier in escrow details

### DIFF
--- a/contracts/Reader.sol
+++ b/contracts/Reader.sol
@@ -115,6 +115,7 @@ struct EscrowDetails {
     address owner;
     int256 tvl;
     uint256 activeJobsCount;
+    uint8 cspTier;
 }
 
 struct UserEscrowDetails {
@@ -182,6 +183,7 @@ interface IPoAIManager {
 interface ICspEscrow {
     function getTotalJobsBalance() external view returns (int256);
     function getActiveJobsCount() external view returns (uint256);
+    function cspTier() external view returns (uint8);
     function getDelegatePermissions(
         address delegate
     ) external view returns (uint256);
@@ -514,7 +516,8 @@ contract Reader is Initializable {
                 escrowAddress: escrowAddr,
                 owner: cspsWithOwner[i].cspOwner,
                 tvl: ICspEscrow(escrowAddr).getTotalJobsBalance(),
-                activeJobsCount: ICspEscrow(escrowAddr).getActiveJobsCount()
+                activeJobsCount: ICspEscrow(escrowAddr).getActiveJobsCount(),
+                cspTier: ICspEscrow(escrowAddr).cspTier()
             });
         }
         return details;
@@ -588,7 +591,8 @@ contract Reader is Initializable {
                     escrowAddress: address(0),
                     owner: address(0),
                     tvl: 0,
-                    activeJobsCount: 0
+                    activeJobsCount: 0,
+                    cspTier: 0
                 });
         }
         return
@@ -596,7 +600,8 @@ contract Reader is Initializable {
                 escrowAddress: escrowAddr,
                 owner: owner,
                 tvl: ICspEscrow(escrowAddr).getTotalJobsBalance(),
-                activeJobsCount: ICspEscrow(escrowAddr).getActiveJobsCount()
+                activeJobsCount: ICspEscrow(escrowAddr).getActiveJobsCount(),
+                cspTier: ICspEscrow(escrowAddr).cspTier()
             });
     }
 

--- a/test/Reader.test.ts
+++ b/test/Reader.test.ts
@@ -328,6 +328,7 @@ describe("Reader contract", function () {
       owner: escrow[1],
       tvl: escrow[2],
       activeJobsCount: escrow[3],
+      cspTier: escrow[4],
     };
   }
 
@@ -877,6 +878,7 @@ describe("Reader contract", function () {
       const escrowAddress = await poaiManager.ownerToEscrow(
         await owner.getAddress()
       );
+      await poaiManager.connect(owner).setCspTier(await owner.getAddress(), 2);
 
       const result = await reader.getAllEscrowsDetails();
       const mapped = result.map(formatEscrowDetails);
@@ -887,6 +889,7 @@ describe("Reader contract", function () {
           owner: await owner.getAddress(),
           tvl: 0n,
           activeJobsCount: 0n,
+          cspTier: 2n,
         },
       ]);
     });
@@ -902,6 +905,7 @@ describe("Reader contract", function () {
         owner: NULL_ADDRESS,
         tvl: 0n,
         activeJobsCount: 0n,
+        cspTier: 0n,
       });
     });
 
@@ -924,6 +928,7 @@ describe("Reader contract", function () {
       const escrowAddress = await poaiManager.ownerToEscrow(
         await owner.getAddress()
       );
+      await poaiManager.connect(owner).setCspTier(await owner.getAddress(), 2);
 
       const result = await reader.getEscrowDetailsByOwner(
         await owner.getAddress()
@@ -935,6 +940,7 @@ describe("Reader contract", function () {
         owner: await owner.getAddress(),
         tvl: 0n,
         activeJobsCount: 0n,
+        cspTier: 2n,
       });
     });
   });


### PR DESCRIPTION
## Summary
- add `cspTier` to `Reader.getAllEscrowsDetails()` and `getEscrowDetailsByOwner()` return structs
- read the tier directly from each CSP escrow in the reader
- update reader tests for the expanded escrow detail payload

## Validation
- `npm run build`
- `npx hardhat test test/Reader.test.ts`
- `npx prettier --check test/Reader.test.ts`
- `git diff --check`
