### PR TITLE
Add initiated CSP escrow owner transfer

### DIFF
--- a/contracts/CspEscrow.sol
+++ b/contracts/CspEscrow.sol
@@ -196,6 +196,10 @@ contract CspEscrow is Initializable {
     );
     event DelegateRemoved(address indexed delegate);
     event CspTierUpdated(uint8 previousTier, uint8 newTier);
+    event CspOwnerChanged(
+        address indexed previousOwner,
+        address indexed newOwner
+    );
 
     //.########.##....##.########..########...#######..####.##....##.########..######.
     //.##.......###...##.##.....##.##.....##.##.....##..##..###...##....##....##....##
@@ -753,6 +757,15 @@ contract CspEscrow is Initializable {
         uint8 previousTier = cspTier;
         cspTier = newTier;
         emit CspTierUpdated(previousTier, newTier);
+    }
+
+    function setCspOwnerFromManager(
+        address newOwner
+    ) external onlyPoAIManager {
+        require(newOwner != address(0), "CSP owner cannot be zero address");
+        address previousOwner = cspOwner;
+        cspOwner = newOwner;
+        emit CspOwnerChanged(previousOwner, newOwner);
     }
 
     function reconcileAllJobs() external onlyPoAIManager {

--- a/contracts/PoAIManager.sol
+++ b/contracts/PoAIManager.sol
@@ -107,6 +107,9 @@ error AlreadyReconciled();
 error TimestampBeforeStartEpoch();
 error NotCspEscrow();
 error CspEscrowDoesNotExist();
+error InvalidCspOwner();
+error SameCspOwner();
+error EscrowOwnerMismatch();
 
 contract PoAIManager is Initializable, OwnableUpgradeable {
     //..######..########..#######..########.....###.....######...########
@@ -214,6 +217,11 @@ contract PoAIManager is Initializable, OwnableUpgradeable {
         address indexed escrow,
         uint8 newTier
     );
+    event CspEscrowOwnerMigrated(
+        address indexed escrow,
+        address indexed oldOwner,
+        address indexed newOwner
+    );
 
     //.########.##....##.########..########...#######..####.##....##.########..######.
     //.##.......###...##.##.....##.##.....##.##.....##..##..###...##....##....##....##
@@ -297,6 +305,40 @@ contract PoAIManager is Initializable, OwnableUpgradeable {
 
         CspEscrow(escrowAddress).setCspTier(newTier);
         emit CspTierUpdated(cspOwner, escrowAddress, newTier);
+    }
+
+    function migrateCspEscrowOwner(
+        address oldOwner,
+        address newOwner
+    ) external onlyOwner {
+        if (oldOwner == address(0) || newOwner == address(0)) {
+            revert InvalidCspOwner();
+        }
+        if (oldOwner == newOwner) {
+            revert SameCspOwner();
+        }
+
+        address escrowAddress = ownerToEscrow[oldOwner];
+        if (escrowAddress == address(0)) {
+            revert CspEscrowDoesNotExist();
+        }
+        if (ownerToEscrow[newOwner] != address(0)) {
+            revert AddressAlreadyOwnsEscrow();
+        }
+        if (delegatedAddressToEscrow[newOwner] != address(0)) {
+            revert AddressDelegatedToAnotherEscrow();
+        }
+        if (escrowToOwner[escrowAddress] != oldOwner) {
+            revert EscrowOwnerMismatch();
+        }
+
+        delete ownerToEscrow[oldOwner];
+        ownerToEscrow[newOwner] = escrowAddress;
+        escrowToOwner[escrowAddress] = newOwner;
+
+        CspEscrow(escrowAddress).setCspOwnerFromManager(newOwner);
+
+        emit CspEscrowOwnerMigrated(escrowAddress, oldOwner, newOwner);
     }
 
     // Internal function to check if user owns at least one ND or MND with a linked node address that is an oracle

--- a/contracts/PoAIManager.sol
+++ b/contracts/PoAIManager.sol
@@ -110,6 +110,7 @@ error CspEscrowDoesNotExist();
 error InvalidCspOwner();
 error SameCspOwner();
 error EscrowOwnerMismatch();
+error CspEscrowOwnerTransferNotInitiated();
 
 contract PoAIManager is Initializable, OwnableUpgradeable {
     //..######..########..#######..########.....###.....######...########
@@ -168,6 +169,8 @@ contract PoAIManager is Initializable, OwnableUpgradeable {
     mapping(address => address) public delegatedAddressToEscrow;
     address public burnContract;
     IAdoptionOracle public adoptionOracle;
+    // Mapping from current CSP owner to the protocol-approved transfer receiver
+    mapping(address => address) public initiatedCspOwnerTransferReceiver;
 
     //.########.##.....##.########.##....##.########..######.
     //.##.......##.....##.##.......###...##....##....##....##
@@ -217,7 +220,12 @@ contract PoAIManager is Initializable, OwnableUpgradeable {
         address indexed escrow,
         uint8 newTier
     );
-    event CspEscrowOwnerMigrated(
+    event CspEscrowOwnerTransferInitiated(
+        address indexed escrow,
+        address indexed oldOwner,
+        address indexed newOwner
+    );
+    event CspEscrowOwnerTransferred(
         address indexed escrow,
         address indexed oldOwner,
         address indexed newOwner
@@ -307,10 +315,42 @@ contract PoAIManager is Initializable, OwnableUpgradeable {
         emit CspTierUpdated(cspOwner, escrowAddress, newTier);
     }
 
-    function migrateCspEscrowOwner(
+    function initiateCspEscrowOwnerTransfer(
         address oldOwner,
         address newOwner
     ) external onlyOwner {
+        address escrowAddress = _validateCspEscrowOwnerTransfer(
+            oldOwner,
+            newOwner
+        );
+
+        initiatedCspOwnerTransferReceiver[oldOwner] = newOwner;
+
+        emit CspEscrowOwnerTransferInitiated(
+            escrowAddress,
+            oldOwner,
+            newOwner
+        );
+    }
+
+    function transferCspEscrowOwnership(address newOwner) external {
+        address oldOwner = msg.sender;
+        address escrowAddress = _validateCspEscrowOwnerTransfer(
+            oldOwner,
+            newOwner
+        );
+        if (initiatedCspOwnerTransferReceiver[oldOwner] != newOwner) {
+            revert CspEscrowOwnerTransferNotInitiated();
+        }
+
+        delete initiatedCspOwnerTransferReceiver[oldOwner];
+        _transferCspEscrowOwnership(escrowAddress, oldOwner, newOwner);
+    }
+
+    function _validateCspEscrowOwnerTransfer(
+        address oldOwner,
+        address newOwner
+    ) internal view returns (address escrowAddress) {
         if (oldOwner == address(0) || newOwner == address(0)) {
             revert InvalidCspOwner();
         }
@@ -318,7 +358,7 @@ contract PoAIManager is Initializable, OwnableUpgradeable {
             revert SameCspOwner();
         }
 
-        address escrowAddress = ownerToEscrow[oldOwner];
+        escrowAddress = ownerToEscrow[oldOwner];
         if (escrowAddress == address(0)) {
             revert CspEscrowDoesNotExist();
         }
@@ -331,14 +371,20 @@ contract PoAIManager is Initializable, OwnableUpgradeable {
         if (escrowToOwner[escrowAddress] != oldOwner) {
             revert EscrowOwnerMismatch();
         }
+    }
 
+    function _transferCspEscrowOwnership(
+        address escrowAddress,
+        address oldOwner,
+        address newOwner
+    ) internal {
         delete ownerToEscrow[oldOwner];
         ownerToEscrow[newOwner] = escrowAddress;
         escrowToOwner[escrowAddress] = newOwner;
 
         CspEscrow(escrowAddress).setCspOwnerFromManager(newOwner);
 
-        emit CspEscrowOwnerMigrated(escrowAddress, oldOwner, newOwner);
+        emit CspEscrowOwnerTransferred(escrowAddress, oldOwner, newOwner);
     }
 
     // Internal function to check if user owns at least one ND or MND with a linked node address that is an oracle

--- a/test/PoAI.test.ts
+++ b/test/PoAI.test.ts
@@ -539,6 +539,227 @@ describe("PoAIManager", function () {
     });
   });
 
+  describe("CSP escrow owner migration", function () {
+    it("allows PoAI manager owner to migrate escrow ownership", async function () {
+      const escrowAddress = await setupUserWithEscrow(user, oracle);
+      const oldOwner = await user.getAddress();
+      const newOwner = await other.getAddress();
+      const cspEscrow = (await ethers.getContractAt(
+        "CspEscrow",
+        escrowAddress
+      )) as unknown as CspEscrow;
+
+      await expect(
+        poaiManager.connect(owner).migrateCspEscrowOwner(oldOwner, newOwner)
+      )
+        .to.emit(cspEscrow, "CspOwnerChanged")
+        .withArgs(oldOwner, newOwner)
+        .and.to.emit(poaiManager, "CspEscrowOwnerMigrated")
+        .withArgs(escrowAddress, oldOwner, newOwner);
+
+      expect(await poaiManager.ownerToEscrow(oldOwner)).to.equal(
+        ethers.ZeroAddress
+      );
+      expect(await poaiManager.ownerToEscrow(newOwner)).to.equal(
+        escrowAddress
+      );
+      expect(await poaiManager.escrowToOwner(escrowAddress)).to.equal(newOwner);
+      expect(await cspEscrow.cspOwner()).to.equal(newOwner);
+
+      expect(await poaiManager.getAddressRegistration(oldOwner)).to.deep.equal(
+        [false, ethers.ZeroAddress]
+      );
+      expect(await poaiManager.getAddressRegistration(newOwner)).to.deep.equal(
+        [true, escrowAddress]
+      );
+    });
+
+    it("preserves escrow jobs and CSP tier during ownership migration", async function () {
+      const escrowAddress = await setupUserWithEscrow(user, oracle);
+      const oldOwner = await user.getAddress();
+      const newOwner = await other.getAddress();
+      const cspEscrow = (await ethers.getContractAt(
+        "CspEscrow",
+        escrowAddress
+      )) as unknown as CspEscrow;
+
+      await poaiManager.connect(owner).setCspTier(oldOwner, 2);
+
+      const currentEpoch = await poaiManager.getCurrentEpoch();
+      const lastExecutionEpoch = currentEpoch + 35n;
+      const numberOfNodesRequested = 1n;
+      const jobPrice =
+        (await cspEscrow.getPriceForJobType(1)) *
+        numberOfNodesRequested *
+        (lastExecutionEpoch - currentEpoch);
+
+      await mockUsdc.mint(oldOwner, jobPrice);
+      await mockUsdc.connect(user).approve(escrowAddress, jobPrice);
+      await cspEscrow.connect(user).createJobs([
+        {
+          jobType: 1,
+          projectHash: ethers.keccak256(
+            ethers.toUtf8Bytes("migration-project")
+          ),
+          lastExecutionEpoch,
+          numberOfNodesRequested,
+        },
+      ]);
+
+      await poaiManager
+        .connect(owner)
+        .migrateCspEscrowOwner(oldOwner, newOwner);
+
+      const activeJobs = await cspEscrow.getActiveJobs();
+      expect(activeJobs.length).to.equal(1);
+      expect(activeJobs[0].id).to.equal(1);
+      expect(await poaiManager.jobIdToEscrow(1)).to.equal(escrowAddress);
+
+      const jobDetails = await poaiManager.getJobDetails(1);
+      expect(jobDetails.escrowAddress).to.equal(escrowAddress);
+      expect(jobDetails.escrowOwner).to.equal(newOwner);
+      expect(await cspEscrow.cspTier()).to.equal(2);
+      expect(await poaiManager.getCspTier(newOwner)).to.equal(2);
+      expect(await poaiManager.getCspTier(oldOwner)).to.equal(0);
+    });
+
+    it("moves owner-only escrow permissions to the new owner", async function () {
+      const escrowAddress = await setupUserWithEscrow(user, oracle);
+      const oldOwner = await user.getAddress();
+      const newOwner = await other.getAddress();
+      const delegate = await oracle2.getAddress();
+      const cspEscrow = (await ethers.getContractAt(
+        "CspEscrow",
+        escrowAddress
+      )) as unknown as CspEscrow;
+
+      await poaiManager
+        .connect(owner)
+        .migrateCspEscrowOwner(oldOwner, newOwner);
+
+      await expect(
+        cspEscrow
+          .connect(user)
+          .setDelegatePermissions(delegate, PERMISSION_CREATE_JOBS)
+      ).to.be.revertedWith("Not CSP owner");
+
+      await expect(
+        cspEscrow
+          .connect(other)
+          .setDelegatePermissions(delegate, PERMISSION_CREATE_JOBS)
+      )
+        .to.emit(cspEscrow, "DelegatePermissionsUpdated")
+        .withArgs(delegate, PERMISSION_CREATE_JOBS);
+    });
+
+    it("prevents non-owner accounts from migrating escrow ownership", async function () {
+      const escrowAddress = await setupUserWithEscrow(user, oracle);
+
+      await expect(
+        poaiManager
+          .connect(user)
+          .migrateCspEscrowOwner(
+            await user.getAddress(),
+            await other.getAddress()
+          )
+      ).to.be.revertedWithCustomError(
+        poaiManager,
+        "OwnableUnauthorizedAccount"
+      );
+
+      expect(await poaiManager.escrowToOwner(escrowAddress)).to.equal(
+        await user.getAddress()
+      );
+    });
+
+    it("reverts for invalid migration addresses", async function () {
+      await setupUserWithEscrow(user, oracle);
+      const oldOwner = await user.getAddress();
+      const newOwner = await other.getAddress();
+
+      await expect(
+        poaiManager
+          .connect(owner)
+          .migrateCspEscrowOwner(ethers.ZeroAddress, newOwner)
+      ).to.be.revertedWithCustomError(poaiManager, "InvalidCspOwner");
+
+      await expect(
+        poaiManager
+          .connect(owner)
+          .migrateCspEscrowOwner(oldOwner, ethers.ZeroAddress)
+      ).to.be.revertedWithCustomError(poaiManager, "InvalidCspOwner");
+
+      await expect(
+        poaiManager.connect(owner).migrateCspEscrowOwner(oldOwner, oldOwner)
+      ).to.be.revertedWithCustomError(poaiManager, "SameCspOwner");
+    });
+
+    it("reverts when old owner has no escrow", async function () {
+      await expect(
+        poaiManager
+          .connect(owner)
+          .migrateCspEscrowOwner(
+            await user.getAddress(),
+            await other.getAddress()
+          )
+      ).to.be.revertedWithCustomError(
+        poaiManager,
+        "CspEscrowDoesNotExist"
+      );
+    });
+
+    it("reverts when new owner already owns an escrow", async function () {
+      await controller.addOracle(await oracle2.getAddress());
+      await setupUserWithEscrow(user, oracle);
+      await setupUserWithEscrow(other, oracle2);
+
+      await expect(
+        poaiManager
+          .connect(owner)
+          .migrateCspEscrowOwner(
+            await user.getAddress(),
+            await other.getAddress()
+          )
+      ).to.be.revertedWithCustomError(
+        poaiManager,
+        "AddressAlreadyOwnsEscrow"
+      );
+    });
+
+    it("reverts when new owner is already delegated to an escrow", async function () {
+      const escrowAddress = await setupUserWithEscrow(user, oracle);
+      const oldOwner = await user.getAddress();
+      const newOwner = await other.getAddress();
+      const cspEscrow = (await ethers.getContractAt(
+        "CspEscrow",
+        escrowAddress
+      )) as unknown as CspEscrow;
+
+      await cspEscrow
+        .connect(user)
+        .setDelegatePermissions(newOwner, PERMISSION_CREATE_JOBS);
+
+      await expect(
+        poaiManager.connect(owner).migrateCspEscrowOwner(oldOwner, newOwner)
+      ).to.be.revertedWithCustomError(
+        poaiManager,
+        "AddressDelegatedToAnotherEscrow"
+      );
+    });
+
+    it("prevents direct CSP owner updates by non-manager accounts", async function () {
+      const escrowAddress = await setupUserWithEscrow(user, oracle);
+      const cspEscrow = (await ethers.getContractAt(
+        "CspEscrow",
+        escrowAddress
+      )) as unknown as CspEscrow;
+
+      await expect(
+        cspEscrow.connect(user).setCspOwnerFromManager(await other.getAddress())
+      ).to.be.revertedWith("Not PoAI Manager");
+    });
+  });
+
   it("should allow CSP owner to create a job", async function () {
     const escrowAddress = await setupUserWithEscrow(user, oracle);
     const CspEscrow = await ethers.getContractFactory("CspEscrow");

--- a/test/PoAI.test.ts
+++ b/test/PoAI.test.ts
@@ -539,8 +539,21 @@ describe("PoAIManager", function () {
     });
   });
 
-  describe("CSP escrow owner migration", function () {
-    it("allows PoAI manager owner to migrate escrow ownership", async function () {
+  describe("CSP escrow owner transfer", function () {
+    async function initiateAndTransferCspEscrowOwnership(
+      oldOwnerSigner: Signer,
+      oldOwner: string,
+      newOwner: string
+    ) {
+      await poaiManager
+        .connect(owner)
+        .initiateCspEscrowOwnerTransfer(oldOwner, newOwner);
+      await poaiManager
+        .connect(oldOwnerSigner)
+        .transferCspEscrowOwnership(newOwner);
+    }
+
+    it("allows PoAI manager owner to initiate and CSP owner to transfer escrow ownership", async function () {
       const escrowAddress = await setupUserWithEscrow(user, oracle);
       const oldOwner = await user.getAddress();
       const newOwner = await other.getAddress();
@@ -550,11 +563,23 @@ describe("PoAIManager", function () {
       )) as unknown as CspEscrow;
 
       await expect(
-        poaiManager.connect(owner).migrateCspEscrowOwner(oldOwner, newOwner)
+        poaiManager
+          .connect(owner)
+          .initiateCspEscrowOwnerTransfer(oldOwner, newOwner)
+      )
+        .to.emit(poaiManager, "CspEscrowOwnerTransferInitiated")
+        .withArgs(escrowAddress, oldOwner, newOwner);
+
+      expect(
+        await poaiManager.initiatedCspOwnerTransferReceiver(oldOwner)
+      ).to.equal(newOwner);
+
+      await expect(
+        poaiManager.connect(user).transferCspEscrowOwnership(newOwner)
       )
         .to.emit(cspEscrow, "CspOwnerChanged")
         .withArgs(oldOwner, newOwner)
-        .and.to.emit(poaiManager, "CspEscrowOwnerMigrated")
+        .and.to.emit(poaiManager, "CspEscrowOwnerTransferred")
         .withArgs(escrowAddress, oldOwner, newOwner);
 
       expect(await poaiManager.ownerToEscrow(oldOwner)).to.equal(
@@ -565,6 +590,9 @@ describe("PoAIManager", function () {
       );
       expect(await poaiManager.escrowToOwner(escrowAddress)).to.equal(newOwner);
       expect(await cspEscrow.cspOwner()).to.equal(newOwner);
+      expect(
+        await poaiManager.initiatedCspOwnerTransferReceiver(oldOwner)
+      ).to.equal(ethers.ZeroAddress);
 
       expect(await poaiManager.getAddressRegistration(oldOwner)).to.deep.equal(
         [false, ethers.ZeroAddress]
@@ -574,7 +602,7 @@ describe("PoAIManager", function () {
       );
     });
 
-    it("preserves escrow jobs and CSP tier during ownership migration", async function () {
+    it("preserves escrow jobs and CSP tier during ownership transfer", async function () {
       const escrowAddress = await setupUserWithEscrow(user, oracle);
       const oldOwner = await user.getAddress();
       const newOwner = await other.getAddress();
@@ -606,9 +634,7 @@ describe("PoAIManager", function () {
         },
       ]);
 
-      await poaiManager
-        .connect(owner)
-        .migrateCspEscrowOwner(oldOwner, newOwner);
+      await initiateAndTransferCspEscrowOwnership(user, oldOwner, newOwner);
 
       const activeJobs = await cspEscrow.getActiveJobs();
       expect(activeJobs.length).to.equal(1);
@@ -633,9 +659,7 @@ describe("PoAIManager", function () {
         escrowAddress
       )) as unknown as CspEscrow;
 
-      await poaiManager
-        .connect(owner)
-        .migrateCspEscrowOwner(oldOwner, newOwner);
+      await initiateAndTransferCspEscrowOwnership(user, oldOwner, newOwner);
 
       await expect(
         cspEscrow
@@ -652,13 +676,13 @@ describe("PoAIManager", function () {
         .withArgs(delegate, PERMISSION_CREATE_JOBS);
     });
 
-    it("prevents non-owner accounts from migrating escrow ownership", async function () {
+    it("prevents non-owner accounts from initiating escrow ownership transfer", async function () {
       const escrowAddress = await setupUserWithEscrow(user, oracle);
 
       await expect(
         poaiManager
           .connect(user)
-          .migrateCspEscrowOwner(
+          .initiateCspEscrowOwnerTransfer(
             await user.getAddress(),
             await other.getAddress()
           )
@@ -672,7 +696,20 @@ describe("PoAIManager", function () {
       );
     });
 
-    it("reverts for invalid migration addresses", async function () {
+    it("prevents CSP owner transfer without protocol initiation", async function () {
+      await setupUserWithEscrow(user, oracle);
+
+      await expect(
+        poaiManager
+          .connect(user)
+          .transferCspEscrowOwnership(await other.getAddress())
+      ).to.be.revertedWithCustomError(
+        poaiManager,
+        "CspEscrowOwnerTransferNotInitiated"
+      );
+    });
+
+    it("reverts for invalid transfer addresses", async function () {
       await setupUserWithEscrow(user, oracle);
       const oldOwner = await user.getAddress();
       const newOwner = await other.getAddress();
@@ -680,17 +717,19 @@ describe("PoAIManager", function () {
       await expect(
         poaiManager
           .connect(owner)
-          .migrateCspEscrowOwner(ethers.ZeroAddress, newOwner)
+          .initiateCspEscrowOwnerTransfer(ethers.ZeroAddress, newOwner)
       ).to.be.revertedWithCustomError(poaiManager, "InvalidCspOwner");
 
       await expect(
         poaiManager
           .connect(owner)
-          .migrateCspEscrowOwner(oldOwner, ethers.ZeroAddress)
+          .initiateCspEscrowOwnerTransfer(oldOwner, ethers.ZeroAddress)
       ).to.be.revertedWithCustomError(poaiManager, "InvalidCspOwner");
 
       await expect(
-        poaiManager.connect(owner).migrateCspEscrowOwner(oldOwner, oldOwner)
+        poaiManager
+          .connect(owner)
+          .initiateCspEscrowOwnerTransfer(oldOwner, oldOwner)
       ).to.be.revertedWithCustomError(poaiManager, "SameCspOwner");
     });
 
@@ -698,7 +737,7 @@ describe("PoAIManager", function () {
       await expect(
         poaiManager
           .connect(owner)
-          .migrateCspEscrowOwner(
+          .initiateCspEscrowOwnerTransfer(
             await user.getAddress(),
             await other.getAddress()
           )
@@ -716,7 +755,7 @@ describe("PoAIManager", function () {
       await expect(
         poaiManager
           .connect(owner)
-          .migrateCspEscrowOwner(
+          .initiateCspEscrowOwnerTransfer(
             await user.getAddress(),
             await other.getAddress()
           )
@@ -740,7 +779,9 @@ describe("PoAIManager", function () {
         .setDelegatePermissions(newOwner, PERMISSION_CREATE_JOBS);
 
       await expect(
-        poaiManager.connect(owner).migrateCspEscrowOwner(oldOwner, newOwner)
+        poaiManager
+          .connect(owner)
+          .initiateCspEscrowOwnerTransfer(oldOwner, newOwner)
       ).to.be.revertedWithCustomError(
         poaiManager,
         "AddressDelegatedToAnotherEscrow"


### PR DESCRIPTION
## Summary
- Replace the direct admin CSP escrow migration path with an MND-style initiated transfer flow.
- Add `initiateCspEscrowOwnerTransfer(oldOwner, newOwner)` for protocol-owner approval and `transferCspEscrowOwnership(newOwner)` for the current CSP owner to execute the transfer.
- Keep the existing manager-only `CspEscrow` owner setter as the internal escrow handoff mechanism.
- Cover transfer initiation, owner-signed execution, job/tier preservation, permission handoff, and revert cases in PoAI tests.

## Impact
This lets protocol admins approve a CSP escrow owner transfer while requiring the current CSP owner wallet to sign the actual handoff, matching the MND initiated-transfer model. The existing escrow contract, active jobs, job mappings, and CSP tier are preserved. It does not migrate Deeploy node/API owner metadata; that remains a separate follow-up for already running pipelines.

## Validation
- `npm run build`
- `npx hardhat test test/PoAI.test.ts`
- `npm run test`
- `npx hardhat run scripts/ci/check-upgrade-safety.ts` (local run had no `UPGRADE_TARGETS`, so it skipped target validation; PR CI runs this with configured targets)